### PR TITLE
Add print layout view and STL export functionality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,9 +25,9 @@ React-Finity is a browser-based parametric 3D modeling app for the Gridfinity mo
 src/
 ├── app/                    # App entry point & layout
 ├── components/
-│   ├── panels/            # Left (object list) & right (properties) panels
+│   ├── panels/            # Left (object list) & right (properties/print settings) panels
 │   │   └── modifiers/     # Per-modifier control components
-│   ├── viewport/          # 3D viewport (React Three Fiber canvas)
+│   ├── viewport/          # 3D viewport (React Three Fiber canvas) + print layout viewport
 │   ├── toolbar/           # Top toolbar
 │   └── ui/                # shadcn/ui primitives
 ├── engine/
@@ -35,7 +35,13 @@ src/
 │   │   ├── modifiers/     # Modifier geometry generators (divider, label, scoop, insert, lid)
 │   │   └── __tests__/     # Unit tests for geometry
 │   │       └── modifiers/ # Unit tests for modifier geometry
-│   ├── constants.ts       # Dimension profiles & default params
+│   ├── export/            # Export & print layout utilities
+│   │   ├── mergeObjectGeometry.ts  # Merge object + modifiers into single geometry
+│   │   ├── printOrientation.ts     # Optimal FDM print orientation per object kind
+│   │   ├── printLayout.ts          # Row-based print bed layout algorithm
+│   │   ├── stlExporter.ts          # STL binary export + ZIP download
+│   │   └── __tests__/     # Unit tests for export modules
+│   ├── constants.ts       # Dimension profiles, default params, print bed presets
 │   └── snapping.ts        # Grid snapping logic
 ├── hooks/                 # Custom React hooks (keyboard shortcuts)
 ├── store/                 # Zustand stores (project, UI, profile)
@@ -54,6 +60,9 @@ e2e/                       # Playwright e2e tests
 - **Zustand stores** are the single source of truth. Components read from stores via selectors. No prop drilling for shared state.
 - **Profile system**: All dimension constants come from `GridfinityProfile` objects (Official, Tight Fit, Loose Fit). Geometry generators receive the active profile, not raw constants.
 - **Properties panels**: One component per object kind (`BaseplateProperties`, `BinProperties`), following the same pattern of sliders/switches with label + value display. BinProperties includes a `ModifierSection` that renders modifier cards recursively.
+- **View mode system**: The app has two views — Edit (design with panels + viewport) and Print Layout (print bed preview + export). `activeView` in `uiStore` controls which view is rendered. The toolbar shows a toggle and conditionally renders view-specific controls.
+- **Export pipeline**: `mergeObjectGeometry.ts` merges an object with all its modifiers into a single `BufferGeometry`. `printOrientation.ts` computes the optimal FDM print rotation. `printLayout.ts` arranges objects on a virtual print bed. `stlExporter.ts` exports to binary STL with optional ZIP bundling.
+- **Shared geometry functions**: `generateModifierGeometry()` and `computeBinContext()` are defined in `src/engine/export/mergeObjectGeometry.ts` and imported by both `SceneObject.tsx` (for viewport rendering) and the export pipeline (for merging). Avoid duplicating these.
 - **Path alias**: `@/` maps to `src/` (configured in vite.config.ts and tsconfig)
 
 ### Adding a New Object Kind
@@ -154,4 +163,5 @@ See `ROADMAP.md` for the full project phases. Current status:
 - Phase 2: Bin Generation & Core Features — Complete
 - Phase 3: Interactivity & Manipulation — Complete
 - Phase 4: Modifier System & Advanced Geometry — Complete
-- Phase 5+: See ROADMAP.md
+- Phase 5: Export & Print Layout — Complete (persistence deferred)
+- Phase 6+: See ROADMAP.md

--- a/README.md
+++ b/README.md
@@ -12,10 +12,13 @@ A browser-based parametric 3D modeling application for the [Gridfinity](https://
   - Scoop -- curved cutout for easy part access
   - Insert -- open-top compartment grid with rim and internal walls
   - Lid -- flat or stacking lid variant
+- **Print Layout view** -- dedicated view with virtual print bed, automatic FDM-optimal orientation, and row-based object arrangement
+- **STL export** -- binary STL export of individual objects, all objects as ZIP, or merged plate STL
+- **Print bed presets** -- configurable bed sizes (220x220, 256x256, 350x350mm) with spacing control
 - **Real-time 3D viewport** -- orbit camera, transform gizmo, grid snapping, measurement overlay
 - **Camera presets** -- top, front, side, and isometric views
 - **Dimension profiles** -- Official, Tight Fit, and Loose Fit presets for all Gridfinity dimensions
-- **Keyboard shortcuts** -- Delete/Backspace to remove objects, Escape to deselect
+- **Keyboard shortcuts** -- Delete/Backspace to remove, Escape to deselect, Ctrl+P for print layout, Ctrl+Shift+E to export
 
 ## Tech Stack
 
@@ -91,6 +94,7 @@ src/
   engine/
     geometry/             Parametric geometry generators
       modifiers/          Modifier geometry generators
+    export/               Export & print layout utilities
     constants.ts          Dimension profiles & default params
     snapping.ts           Grid snapping logic
   hooks/                  Custom React hooks
@@ -108,7 +112,7 @@ See [ROADMAP.md](ROADMAP.md) for the full development plan. Current status:
 - Phase 2: Bin Generation & Core Features -- Complete
 - Phase 3: Interactivity & Manipulation -- Complete
 - Phase 4: Modifier System & Advanced Geometry -- Complete
-- Phase 5: Export & Persistence -- Planned
+- Phase 5: Export & Print Layout -- Complete
 - Phase 6: Polish & Advanced UX -- Planned
 - Phase 7: Desktop App (Tauri) -- Planned
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -95,20 +95,31 @@ Long-term, the app will transition to a native desktop experience via Tauri whil
 
 ---
 
-## Phase 5: Export & Persistence 🔲
+## Phase 5: Export & Print Layout ✅ (partial)
 
-**Status:** Planned
+**Status:** Export & print layout complete; persistence deferred
 
-**Goal:** Export to 3D printing formats and save/load projects.
+**Goal:** Export to 3D printing formats and print-ready visualization.
 
-**Deliverables:**
-- STL export (binary) via Three.js STLExporter — single object or entire scene
+**Delivered:**
+- **Print Layout view** — dedicated view mode with virtual print bed visualization, switchable via toolbar toggle (Edit/Print) or Ctrl+P
+- **Print bed presets** — configurable bed size (220x220mm, 256x256mm, 350x350mm) with grid overlay
+- **Automatic print orientation** — objects oriented optimally for FDM printing (bins flipped upside-down, baseplates flat)
+- **Row-based object arrangement** — objects laid out on the print bed with configurable spacing (5-30mm), sorted by depth for efficient packing
+- **Geometry merging** — each object's modifiers are recursively merged into a single geometry for export
+- **STL export (binary)** — export individual objects or all objects via the Export dropdown or Print Settings panel
+- **ZIP export** — export all objects as individually named STL files bundled in a ZIP
+- **Single plate STL** — export all objects merged at their layout positions as one STL file
+- **Print Settings panel** — bed size selector, spacing slider, per-object dimensions display, fit indicators, and export buttons
+- **Keyboard shortcuts** — Ctrl+Shift+E to export selected object, Ctrl+P to toggle Print Layout view
+- Unit tests for geometry merging, print orientation, layout algorithm, and STL export (27 tests)
+- E2E tests for print layout view and export functionality (22 tests)
+
+**Deferred to later phase:**
 - 3MF export via three-3mf-exporter
-- Local storage persistence — save/load projects as JSON (parameters + modifiers, not geometry)
+- Local storage persistence — save/load projects as JSON
 - Project management — new, save, load, rename, delete
-- Export settings — scale, orientation, polygon quality
-- ZIP download for multi-object exports
-- Ensure modifier geometries are merged/included in exports
+- Export settings — scale, polygon quality
 
 ---
 
@@ -159,7 +170,6 @@ Items that may be explored beyond the core roadmap:
 - **Parametric templates** — saveable parameter presets (e.g., "battery organizer", "screwdriver holder")
 - **Multi-material 3MF** — assign different colors/materials to bin sections
 - **Import reference geometry** — load STL/STEP files to design holders around existing tools
-- **Print plate layout** — arrange multiple objects on a virtual print bed
 - **Slicer integration** — direct export to PrusaSlicer/OrcaSlicer via CLI
 - **Collaborative editing** — real-time multi-user design sessions
 - **Mobile companion** — measure tools with phone camera, send dimensions to desktop

--- a/e2e/export.spec.ts
+++ b/e2e/export.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Export Functionality', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+  })
+
+  test('shows Export dropdown in toolbar', async ({ page }) => {
+    await expect(page.getByRole('button', { name: /Export/ })).toBeVisible()
+  })
+
+  test('Export dropdown shows menu items', async ({ page }) => {
+    await page.getByRole('button', { name: /Export/ }).click()
+
+    await expect(page.getByRole('menuitem', { name: /Export Selected/ })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: /Open Print Layout/ })).toBeVisible()
+  })
+
+  test('Export Selected is disabled when nothing is selected', async ({ page }) => {
+    await page.getByRole('button', { name: /Export/ }).click()
+
+    const exportSelected = page.getByRole('menuitem', { name: /Export Selected/ })
+    await expect(exportSelected).toBeVisible()
+    // Disabled menu items have data-disabled attribute in radix
+    await expect(exportSelected).toHaveAttribute('data-disabled')
+  })
+
+  test('Open Print Layout switches to print view', async ({ page }) => {
+    await page.getByRole('button', { name: /Export/ }).click()
+    await page.getByRole('menuitem', { name: /Open Print Layout/ }).click()
+
+    // Should switch to print layout view
+    await expect(page.getByText('Print Settings')).toBeVisible()
+  })
+
+  test('Export Selected is enabled after selecting an object', async ({ page }) => {
+    // Add and select an object
+    await page.getByRole('button', { name: /Add Object/i }).click()
+    await page.getByRole('menuitem', { name: 'Baseplate' }).click()
+
+    // Open export dropdown
+    await page.getByRole('button', { name: /Export/ }).click()
+
+    // Export Selected should be enabled (no data-disabled attribute)
+    const exportSelected = page.getByRole('menuitem', { name: /Export Selected/ })
+    await expect(exportSelected).not.toHaveAttribute('data-disabled')
+  })
+
+  test('Export triggers download for selected object', async ({ page }) => {
+    // Add and select an object
+    await page.getByRole('button', { name: /Add Object/i }).click()
+    await page.getByRole('menuitem', { name: 'Baseplate' }).click()
+
+    // Set up download listener
+    const downloadPromise = page.waitForEvent('download')
+
+    // Export selected
+    await page.getByRole('button', { name: /Export/ }).click()
+    await page.getByRole('menuitem', { name: /Export Selected/ }).click()
+
+    // Should trigger a download
+    const download = await downloadPromise
+    expect(download.suggestedFilename()).toBe('Baseplate 1.stl')
+  })
+
+  test('Ctrl+P toggles to print layout view', async ({ page }) => {
+    await page.keyboard.press('Control+p')
+
+    // Should switch to print layout view
+    await expect(page.getByText('Print Settings')).toBeVisible()
+
+    // Press again to go back
+    await page.keyboard.press('Control+p')
+    await expect(page.getByRole('button', { name: /Add Object/i })).toBeVisible()
+  })
+
+  test('export buttons are disabled when no objects in print layout', async ({ page }) => {
+    await page.getByRole('button', { name: 'Print layout view' }).click()
+
+    const exportAllBtn = page.getByRole('button', { name: /Export All \(ZIP\)/ })
+    const exportPlateBtn = page.getByRole('button', { name: /Export Plate/ })
+
+    await expect(exportAllBtn).toBeDisabled()
+    await expect(exportPlateBtn).toBeDisabled()
+  })
+
+  test('export buttons are enabled with objects in print layout', async ({ page }) => {
+    // Add objects in edit view
+    await page.getByRole('button', { name: /Add Object/i }).click()
+    await page.getByRole('menuitem', { name: 'Baseplate' }).click()
+
+    // Switch to print layout
+    await page.getByRole('button', { name: 'Print layout view' }).click()
+
+    const exportAllBtn = page.getByRole('button', { name: /Export All \(ZIP\)/ })
+    const exportPlateBtn = page.getByRole('button', { name: /Export Plate/ })
+
+    await expect(exportAllBtn).toBeEnabled()
+    await expect(exportPlateBtn).toBeEnabled()
+  })
+})

--- a/e2e/print-layout.spec.ts
+++ b/e2e/print-layout.spec.ts
@@ -1,0 +1,139 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Print Layout View', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+  })
+
+  test('shows Edit and Print view toggle buttons', async ({ page }) => {
+    await expect(page.getByRole('button', { name: 'Edit view' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Print layout view' })).toBeVisible()
+  })
+
+  test('starts in Edit view by default', async ({ page }) => {
+    // Edit button should be active (pressed)
+    const editBtn = page.getByRole('button', { name: 'Edit view' })
+    await expect(editBtn).toHaveAttribute('aria-pressed', 'true')
+
+    // Edit view controls should be visible
+    await expect(page.getByRole('button', { name: /Add Object/i })).toBeVisible()
+    await expect(page.getByText('Objects', { exact: true })).toBeVisible()
+    await expect(page.getByText('Properties', { exact: true })).toBeVisible()
+  })
+
+  test('switches to Print Layout view', async ({ page }) => {
+    await page.getByRole('button', { name: 'Print layout view' }).click()
+
+    // Print button should now be active
+    const printBtn = page.getByRole('button', { name: 'Print layout view' })
+    await expect(printBtn).toHaveAttribute('aria-pressed', 'true')
+
+    // Print settings panel should be visible
+    await expect(page.getByText('Print Settings')).toBeVisible()
+
+    // Edit view controls should be hidden
+    await expect(page.getByRole('button', { name: /Add Object/i })).not.toBeVisible()
+
+    // Objects panel (left panel) should be hidden
+    await expect(page.getByText('Objects', { exact: true })).not.toBeVisible()
+  })
+
+  test('switches back to Edit view', async ({ page }) => {
+    // Go to print layout
+    await page.getByRole('button', { name: 'Print layout view' }).click()
+    await expect(page.getByText('Print Settings')).toBeVisible()
+
+    // Switch back to edit
+    await page.getByRole('button', { name: 'Edit view' }).click()
+
+    // Edit view should be restored
+    await expect(page.getByRole('button', { name: /Add Object/i })).toBeVisible()
+    await expect(page.getByText('Properties', { exact: true })).toBeVisible()
+  })
+
+  test('shows print bed settings panel with bed size selector', async ({ page }) => {
+    await page.getByRole('button', { name: 'Print layout view' }).click()
+
+    // Bed size selector should be visible
+    await expect(page.getByText('Bed Size')).toBeVisible()
+    await expect(page.getByLabel('Bed size')).toBeVisible()
+  })
+
+  test('shows spacing slider in print settings', async ({ page }) => {
+    await page.getByRole('button', { name: 'Print layout view' }).click()
+
+    await expect(page.getByText('Object Spacing')).toBeVisible()
+    await expect(page.getByText('10 mm')).toBeVisible()
+    await expect(page.getByLabel('Object spacing')).toBeVisible()
+  })
+
+  test('shows empty state when no objects exist', async ({ page }) => {
+    await page.getByRole('button', { name: 'Print layout view' }).click()
+
+    await expect(
+      page.getByText('No objects to export. Add objects in Edit view.'),
+    ).toBeVisible()
+  })
+
+  test('shows objects in print settings after adding in edit view', async ({ page }) => {
+    // Add a baseplate in edit view
+    await page.getByRole('button', { name: /Add Object/i }).click()
+    await page.getByRole('menuitem', { name: 'Baseplate' }).click()
+
+    // Switch to print layout
+    await page.getByRole('button', { name: 'Print layout view' }).click()
+
+    // Should show the object in the list
+    await expect(page.getByText('Baseplate 1')).toBeVisible()
+    await expect(page.getByText('Objects (1)')).toBeVisible()
+  })
+
+  test('shows export buttons in print settings', async ({ page }) => {
+    // Add an object first
+    await page.getByRole('button', { name: /Add Object/i }).click()
+    await page.getByRole('menuitem', { name: 'Baseplate' }).click()
+
+    await page.getByRole('button', { name: 'Print layout view' }).click()
+
+    await expect(page.getByRole('button', { name: /Export All \(ZIP\)/ })).toBeVisible()
+    await expect(page.getByRole('button', { name: /Export Plate/ })).toBeVisible()
+  })
+
+  test('shows per-object export button', async ({ page }) => {
+    await page.getByRole('button', { name: /Add Object/i }).click()
+    await page.getByRole('menuitem', { name: 'Baseplate' }).click()
+
+    await page.getByRole('button', { name: 'Print layout view' }).click()
+
+    // Per-object export button
+    await expect(page.getByRole('button', { name: /Export Baseplate 1/ })).toBeVisible()
+  })
+
+  test('shows dimensions for each object', async ({ page }) => {
+    await page.getByRole('button', { name: /Add Object/i }).click()
+    await page.getByRole('menuitem', { name: 'Baseplate' }).click()
+
+    await page.getByRole('button', { name: 'Print layout view' }).click()
+
+    // Should show dimensions like "126.0 x 126.0 x 7.0 mm" (for 3x3 default baseplate)
+    await expect(page.getByText(/\d+\.\d+ x \d+\.\d+ x \d+\.\d+ mm/)).toBeVisible()
+  })
+
+  test('renders canvas in print layout view', async ({ page }) => {
+    await page.getByRole('button', { name: 'Print layout view' }).click()
+    await expect(page.locator('canvas')).toBeVisible()
+  })
+
+  test('changes bed size preset', async ({ page }) => {
+    await page.getByRole('button', { name: 'Print layout view' }).click()
+
+    // Open the bed size selector
+    await page.getByLabel('Bed size').click()
+
+    // Select a different size
+    await page.getByText('220 x 220 mm').click()
+
+    // Verify selection changed (the trigger should show the new value)
+    await expect(page.getByText('220 x 220 mm')).toBeVisible()
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@tailwindcss/vite": "^4.2.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "jszip": "^3.10.1",
         "lucide-react": "^0.575.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -4205,6 +4206,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cross-env": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
@@ -5097,6 +5104,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -5157,6 +5170,12 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
       "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -5331,6 +5350,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
       }
     },
     "node_modules/keyv": {
@@ -6005,6 +6036,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -6225,6 +6262,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/promise-worker-transferable": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
@@ -6368,6 +6411,21 @@
         }
       }
     },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -6469,6 +6527,12 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -6497,6 +6561,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -6617,6 +6687,15 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/string-argv": {
       "version": "0.3.2",
@@ -7154,6 +7233,12 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/utility-types": {
       "version": "3.11.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@tailwindcss/vite": "^4.2.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "jszip": "^3.10.1",
     "lucide-react": "^0.575.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/src/app/Layout.tsx
+++ b/src/app/Layout.tsx
@@ -1,7 +1,9 @@
 import { Toolbar } from '@/components/toolbar/Toolbar'
 import { ObjectListPanel } from '@/components/panels/ObjectListPanel'
 import { PropertiesPanel } from '@/components/panels/PropertiesPanel'
+import { PrintSettingsPanel } from '@/components/panels/PrintSettingsPanel'
 import { Viewport } from '@/components/viewport/Viewport'
+import { PrintLayoutViewport } from '@/components/viewport/PrintLayoutViewport'
 import { useUIStore } from '@/store/uiStore'
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
 import { cn } from '@/lib/utils'
@@ -9,8 +11,11 @@ import { cn } from '@/lib/utils'
 export function Layout() {
   const leftPanelOpen = useUIStore((s) => s.leftPanelOpen)
   const rightPanelOpen = useUIStore((s) => s.rightPanelOpen)
+  const activeView = useUIStore((s) => s.activeView)
 
   useKeyboardShortcuts()
+
+  const isEditView = activeView === 'edit'
 
   return (
     <div className="flex h-full flex-col">
@@ -19,29 +24,31 @@ export function Layout() {
 
       {/* Main content area */}
       <div className="flex flex-1 overflow-hidden">
-        {/* Left panel - Object list */}
-        <div
-          className={cn(
-            'border-r border-border bg-background transition-all duration-200',
-            leftPanelOpen ? 'w-60' : 'w-0',
-          )}
-        >
-          {leftPanelOpen && <ObjectListPanel />}
-        </div>
+        {/* Left panel - Object list (edit view only) */}
+        {isEditView && (
+          <div
+            className={cn(
+              'border-r border-border bg-background transition-all duration-200',
+              leftPanelOpen ? 'w-60' : 'w-0',
+            )}
+          >
+            {leftPanelOpen && <ObjectListPanel />}
+          </div>
+        )}
 
         {/* Center - 3D Viewport */}
         <div className="flex-1">
-          <Viewport />
+          {isEditView ? <Viewport /> : <PrintLayoutViewport />}
         </div>
 
-        {/* Right panel - Properties */}
+        {/* Right panel - Properties (edit) or Print Settings (print layout) */}
         <div
           className={cn(
             'border-l border-border bg-background transition-all duration-200',
             rightPanelOpen ? 'w-72' : 'w-0',
           )}
         >
-          {rightPanelOpen && <PropertiesPanel />}
+          {rightPanelOpen && (isEditView ? <PropertiesPanel /> : <PrintSettingsPanel />)}
         </div>
       </div>
     </div>

--- a/src/components/panels/PrintSettingsPanel.tsx
+++ b/src/components/panels/PrintSettingsPanel.tsx
@@ -1,0 +1,187 @@
+import { useMemo } from 'react'
+import { Download, Check, AlertTriangle } from 'lucide-react'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { Label } from '@/components/ui/label'
+import { Slider } from '@/components/ui/slider'
+import { Separator } from '@/components/ui/separator'
+import { Button } from '@/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useProjectStore } from '@/store/projectStore'
+import { useProfileStore } from '@/store/profileStore'
+import { useUIStore } from '@/store/uiStore'
+import { PRINT_BED_PRESETS } from '@/engine/constants'
+import { computePrintLayout, disposePrintLayout } from '@/engine/export/printLayout'
+import { mergeObjectWithModifiers } from '@/engine/export/mergeObjectGeometry'
+import { getPrintRotation, applyPrintOrientation } from '@/engine/export/printOrientation'
+import { exportObjectAsSTL, exportAllAsZip, exportAllAsSingleSTL } from '@/engine/export/stlExporter'
+
+export function PrintSettingsPanel() {
+  const objects = useProjectStore((s) => s.objects)
+  const modifiers = useProjectStore((s) => s.modifiers)
+  const activeProfile = useProfileStore((s) => s.activeProfile)
+  const printBedPreset = useUIStore((s) => s.printBedPreset)
+  const printBedSpacing = useUIStore((s) => s.printBedSpacing)
+  const setPrintBedPreset = useUIStore((s) => s.setPrintBedPreset)
+  const setPrintBedSpacing = useUIStore((s) => s.setPrintBedSpacing)
+
+  const bed = PRINT_BED_PRESETS[printBedPreset] ?? PRINT_BED_PRESETS['256x256']
+
+  const layoutItems = useMemo(() => {
+    if (objects.length === 0) return []
+    return computePrintLayout(objects, modifiers, activeProfile, bed.width, bed.depth, printBedSpacing)
+  }, [objects, modifiers, activeProfile, bed.width, bed.depth, printBedSpacing])
+
+  // Dispose on recompute
+  useMemo(() => {
+    return () => { disposePrintLayout(layoutItems) }
+  }, [layoutItems])
+
+  const allFit = layoutItems.every((item) => item.fitsOnBed)
+
+  const handleExportAll = () => {
+    if (layoutItems.length === 0) return
+    void exportAllAsZip(layoutItems)
+  }
+
+  const handleExportSingleSTL = () => {
+    if (layoutItems.length === 0) return
+    exportAllAsSingleSTL(layoutItems)
+  }
+
+  const handleExportOne = (objectId: string) => {
+    const obj = objects.find((o) => o.id === objectId)
+    if (!obj) return
+    const merged = mergeObjectWithModifiers(obj, modifiers, activeProfile)
+    const rotation = getPrintRotation(obj)
+    const oriented = applyPrintOrientation(merged, rotation)
+    exportObjectAsSTL(oriented, obj.name)
+    merged.dispose()
+    oriented.dispose()
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex h-9 items-center border-b border-border px-3">
+        <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          Print Settings
+        </span>
+      </div>
+      <ScrollArea className="flex-1">
+        <div className="space-y-4 p-3">
+          {/* Bed Size */}
+          <div className="space-y-2">
+            <Label className="text-xs">Bed Size</Label>
+            <Select value={printBedPreset} onValueChange={setPrintBedPreset}>
+              <SelectTrigger className="h-8 text-xs" aria-label="Bed size">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {Object.entries(PRINT_BED_PRESETS).map(([key, preset]) => (
+                  <SelectItem key={key} value={key}>
+                    {preset.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Spacing */}
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <Label className="text-xs">Object Spacing</Label>
+              <span className="text-xs text-muted-foreground">{printBedSpacing} mm</span>
+            </div>
+            <Slider
+              min={5}
+              max={30}
+              step={1}
+              value={[printBedSpacing]}
+              onValueChange={([v]) => { setPrintBedSpacing(v) }}
+              aria-label="Object spacing"
+            />
+          </div>
+
+          <Separator />
+
+          {/* Object List */}
+          <div className="space-y-2">
+            <Label className="text-xs">Objects ({layoutItems.length})</Label>
+            {layoutItems.length === 0 ? (
+              <div className="py-4 text-center text-xs text-muted-foreground">
+                No objects to export. Add objects in Edit view.
+              </div>
+            ) : (
+              <div className="space-y-1">
+                {layoutItems.map((item) => (
+                  <div
+                    key={item.object.id}
+                    className="flex items-center gap-2 rounded-md border border-border px-2 py-1.5"
+                  >
+                    {item.fitsOnBed ? (
+                      <Check className="h-3 w-3 shrink-0 text-green-500" />
+                    ) : (
+                      <AlertTriangle className="h-3 w-3 shrink-0 text-yellow-500" />
+                    )}
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-xs font-medium">{item.object.name}</div>
+                      <div className="text-[10px] text-muted-foreground">
+                        {item.boundingBox.width.toFixed(1)} x {item.boundingBox.depth.toFixed(1)} x{' '}
+                        {item.boundingBox.height.toFixed(1)} mm
+                      </div>
+                    </div>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-6 w-6 shrink-0"
+                      onClick={() => { handleExportOne(item.object.id) }}
+                      aria-label={`Export ${item.object.name}`}
+                    >
+                      <Download className="h-3 w-3" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {!allFit && layoutItems.length > 0 && (
+            <div className="rounded-md border border-yellow-500/30 bg-yellow-500/10 p-2 text-[10px] text-yellow-400">
+              Some objects extend beyond the print bed boundary.
+            </div>
+          )}
+
+          <Separator />
+
+          {/* Export Buttons */}
+          <div className="space-y-2">
+            <Button
+              className="w-full gap-2"
+              size="sm"
+              onClick={handleExportAll}
+              disabled={layoutItems.length === 0}
+            >
+              <Download className="h-4 w-4" />
+              Export All (ZIP)
+            </Button>
+            <Button
+              className="w-full gap-2"
+              variant="outline"
+              size="sm"
+              onClick={handleExportSingleSTL}
+              disabled={layoutItems.length === 0}
+            >
+              <Download className="h-4 w-4" />
+              Export Plate (Single STL)
+            </Button>
+          </div>
+        </div>
+      </ScrollArea>
+    </div>
+  )
+}

--- a/src/components/toolbar/Toolbar.tsx
+++ b/src/components/toolbar/Toolbar.tsx
@@ -1,25 +1,36 @@
-import { Plus, PanelLeft, PanelRight, Grid3x3 } from 'lucide-react'
+import { Plus, PanelLeft, PanelRight, Grid3x3, Download, Pencil, Printer } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { CameraPresets } from './CameraPresets'
 import { ViewportSettings } from './ViewportSettings'
 import { useProjectStore } from '@/store/projectStore'
+import { useProfileStore } from '@/store/profileStore'
 import { useUIStore } from '@/store/uiStore'
 import { cn } from '@/lib/utils'
+import { mergeObjectWithModifiers } from '@/engine/export/mergeObjectGeometry'
+import { getPrintRotation, applyPrintOrientation } from '@/engine/export/printOrientation'
+import { exportObjectAsSTL } from '@/engine/export/stlExporter'
 
 export function Toolbar() {
   const addObject = useProjectStore((s) => s.addObject)
+  const objects = useProjectStore((s) => s.objects)
+  const modifiers = useProjectStore((s) => s.modifiers)
   const selectObject = useUIStore((s) => s.selectObject)
+  const selectedObjectId = useUIStore((s) => s.selectedObjectId)
   const toggleLeftPanel = useUIStore((s) => s.toggleLeftPanel)
   const toggleRightPanel = useUIStore((s) => s.toggleRightPanel)
   const snapToGrid = useUIStore((s) => s.snapToGrid)
   const toggleSnapToGrid = useUIStore((s) => s.toggleSnapToGrid)
+  const activeView = useUIStore((s) => s.activeView)
+  const setActiveView = useUIStore((s) => s.setActiveView)
+  const activeProfile = useProfileStore((s) => s.activeProfile)
 
   const handleAddBaseplate = () => {
     const id = addObject('baseplate')
@@ -31,6 +42,21 @@ export function Toolbar() {
     selectObject(id)
   }
 
+  const handleExportSelected = () => {
+    if (!selectedObjectId) return
+    const obj = objects.find((o) => o.id === selectedObjectId)
+    if (!obj) return
+
+    const merged = mergeObjectWithModifiers(obj, modifiers, activeProfile)
+    const rotation = getPrintRotation(obj)
+    const oriented = applyPrintOrientation(merged, rotation)
+    exportObjectAsSTL(oriented, obj.name)
+    merged.dispose()
+    oriented.dispose()
+  }
+
+  const isEditView = activeView === 'edit'
+
   return (
     <div className="flex h-10 items-center gap-2 border-b border-border bg-background px-3">
       {/* Left panel toggle */}
@@ -40,45 +66,96 @@ export function Toolbar() {
 
       <div className="h-5 w-px bg-border" />
 
-      {/* Add object dropdown */}
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button variant="ghost" size="sm" className="h-7 gap-1">
-            <Plus className="h-4 w-4" />
-            Add Object
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent>
-          <DropdownMenuItem onClick={handleAddBaseplate}>Baseplate</DropdownMenuItem>
-          <DropdownMenuItem onClick={handleAddBin}>Bin</DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-
-      <div className="h-5 w-px bg-border" />
-
-      {/* Camera presets */}
-      <CameraPresets />
-
-      <div className="h-5 w-px bg-border" />
-
-      {/* Snap to grid toggle */}
+      {/* View mode toggle */}
       <TooltipProvider delayDuration={300}>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon"
-              className={cn('h-7 w-7', snapToGrid && 'bg-accent text-accent-foreground')}
-              onClick={toggleSnapToGrid}
-              aria-label="Snap to grid"
-              aria-pressed={snapToGrid}
-            >
-              <Grid3x3 className="h-4 w-4" />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>Snap to grid</TooltipContent>
-        </Tooltip>
+        <div className="flex items-center gap-0.5 rounded-md border border-border p-0.5">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className={cn(
+                  'h-6 gap-1 px-2 text-xs',
+                  isEditView && 'bg-accent text-accent-foreground',
+                )}
+                onClick={() => { setActiveView('edit') }}
+                aria-label="Edit view"
+                aria-pressed={isEditView}
+              >
+                <Pencil className="h-3 w-3" />
+                Edit
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Edit view</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className={cn(
+                  'h-6 gap-1 px-2 text-xs',
+                  !isEditView && 'bg-accent text-accent-foreground',
+                )}
+                onClick={() => { setActiveView('printLayout') }}
+                aria-label="Print layout view"
+                aria-pressed={!isEditView}
+              >
+                <Printer className="h-3 w-3" />
+                Print
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Print layout view</TooltipContent>
+          </Tooltip>
+        </div>
       </TooltipProvider>
+
+      <div className="h-5 w-px bg-border" />
+
+      {/* Edit view controls */}
+      {isEditView && (
+        <>
+          {/* Add object dropdown */}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="sm" className="h-7 gap-1">
+                <Plus className="h-4 w-4" />
+                Add Object
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+              <DropdownMenuItem onClick={handleAddBaseplate}>Baseplate</DropdownMenuItem>
+              <DropdownMenuItem onClick={handleAddBin}>Bin</DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          <div className="h-5 w-px bg-border" />
+
+          {/* Camera presets */}
+          <CameraPresets />
+
+          <div className="h-5 w-px bg-border" />
+
+          {/* Snap to grid toggle */}
+          <TooltipProvider delayDuration={300}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className={cn('h-7 w-7', snapToGrid && 'bg-accent text-accent-foreground')}
+                  onClick={toggleSnapToGrid}
+                  aria-label="Snap to grid"
+                  aria-pressed={snapToGrid}
+                >
+                  <Grid3x3 className="h-4 w-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Snap to grid</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </>
+      )}
 
       {/* Spacer */}
       <div className="flex-1" />
@@ -89,8 +166,38 @@ export function Toolbar() {
       {/* Spacer */}
       <div className="flex-1" />
 
-      {/* Viewport settings */}
-      <ViewportSettings />
+      {/* Export dropdown */}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="sm" className="h-7 gap-1">
+            <Download className="h-4 w-4" />
+            Export
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            onClick={handleExportSelected}
+            disabled={!selectedObjectId || !isEditView}
+          >
+            Export Selected (STL)
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onClick={() => { setActiveView('printLayout') }}
+            disabled={!isEditView}
+          >
+            Open Print Layout
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {/* Viewport settings (edit view only) */}
+      {isEditView && (
+        <>
+          <div className="h-5 w-px bg-border" />
+          <ViewportSettings />
+        </>
+      )}
 
       <div className="h-5 w-px bg-border" />
 

--- a/src/components/viewport/PrintLayoutViewport.tsx
+++ b/src/components/viewport/PrintLayoutViewport.tsx
@@ -1,0 +1,141 @@
+import { useMemo } from 'react'
+import * as THREE from 'three'
+import { Canvas } from '@react-three/fiber'
+import { OrbitControls, GizmoHelper, GizmoViewport } from '@react-three/drei'
+import { useProjectStore } from '@/store/projectStore'
+import { useProfileStore } from '@/store/profileStore'
+import { useUIStore } from '@/store/uiStore'
+import { PRINT_BED_PRESETS } from '@/engine/constants'
+import { computePrintLayout, disposePrintLayout } from '@/engine/export/printLayout'
+import type { PrintLayoutItem } from '@/engine/export/printLayout'
+
+function PrintBed({ width, depth }: { width: number; depth: number }) {
+  const gridSize = 42 // Gridfinity grid spacing in mm
+
+  const gridHelper = useMemo(() => {
+    const divisionsX = Math.floor(width / gridSize)
+    const divisionsZ = Math.floor(depth / gridSize)
+    const divisions = Math.max(divisionsX, divisionsZ)
+    const size = Math.max(width, depth)
+    const grid = new THREE.GridHelper(size, divisions, '#444444', '#333333')
+    grid.position.set(width / 2, 0, depth / 2)
+    return grid
+  }, [width, depth])
+
+  return (
+    <>
+      {/* Bed surface */}
+      <mesh position={[width / 2, -0.1, depth / 2]} rotation={[-Math.PI / 2, 0, 0]}>
+        <planeGeometry args={[width, depth]} />
+        <meshStandardMaterial color="#2a2a3e" transparent opacity={0.8} side={THREE.DoubleSide} />
+      </mesh>
+
+      {/* Bed outline */}
+      <lineSegments position={[width / 2, 0.05, depth / 2]}>
+        <edgesGeometry
+          args={[new THREE.PlaneGeometry(width, depth)]}
+        />
+        <lineBasicMaterial color="#6b9bd2" linewidth={2} />
+      </lineSegments>
+
+      {/* Grid overlay */}
+      <primitive object={gridHelper} />
+    </>
+  )
+}
+
+function PrintObject({ item }: { item: PrintLayoutItem }) {
+  const [x, y, z] = item.position
+
+  return (
+    <mesh geometry={item.geometry} position={[x, y, z]}>
+      <meshStandardMaterial
+        color={item.fitsOnBed ? '#b0b0b0' : '#e74c3c'}
+        roughness={0.6}
+        metalness={0.1}
+        transparent={!item.fitsOnBed}
+        opacity={item.fitsOnBed ? 1 : 0.7}
+      />
+    </mesh>
+  )
+}
+
+function PrintScene() {
+  const objects = useProjectStore((s) => s.objects)
+  const modifiers = useProjectStore((s) => s.modifiers)
+  const activeProfile = useProfileStore((s) => s.activeProfile)
+  const printBedPreset = useUIStore((s) => s.printBedPreset)
+  const printBedSpacing = useUIStore((s) => s.printBedSpacing)
+
+  const bed = PRINT_BED_PRESETS[printBedPreset] ?? PRINT_BED_PRESETS['256x256']
+
+  const layoutItems = useMemo(() => {
+    if (objects.length === 0) return []
+    const items = computePrintLayout(
+      objects,
+      modifiers,
+      activeProfile,
+      bed.width,
+      bed.depth,
+      printBedSpacing,
+    )
+    return items
+  }, [objects, modifiers, activeProfile, bed.width, bed.depth, printBedSpacing])
+
+  // Dispose previous layout geometries on unmount/recompute
+  useMemo(() => {
+    return () => { disposePrintLayout(layoutItems) }
+  }, [layoutItems])
+
+  return (
+    <>
+      {/* Lighting */}
+      <ambientLight intensity={0.6} />
+      <directionalLight position={[200, 400, 200]} intensity={0.8} />
+      <directionalLight position={[-100, 200, -100]} intensity={0.3} />
+
+      {/* Camera controls */}
+      <OrbitControls
+        makeDefault
+        minDistance={20}
+        maxDistance={2000}
+        enableDamping
+        dampingFactor={0.1}
+      />
+
+      {/* Print bed */}
+      <PrintBed width={bed.width} depth={bed.depth} />
+
+      {/* Objects on the print bed */}
+      {layoutItems.map((item) => (
+        <PrintObject key={item.object.id} item={item} />
+      ))}
+
+      {/* Gizmo helper */}
+      <GizmoHelper alignment="bottom-right" margin={[60, 60]}>
+        <GizmoViewport axisColors={['#e74c3c', '#2ecc71', '#3498db']} labelColor="white" />
+      </GizmoHelper>
+    </>
+  )
+}
+
+export function PrintLayoutViewport() {
+  return (
+    <div className="h-full w-full">
+      <Canvas
+        camera={{
+          position: [200, 300, 200],
+          fov: 50,
+          near: 0.1,
+          far: 10000,
+        }}
+        shadows
+        gl={{ antialias: true }}
+      >
+        <color attach="background" args={['#1a1a2e']} />
+        <fog attach="fog" args={['#1a1a2e', 1000, 3000]} />
+        <PrintScene />
+      </Canvas>
+    </div>
+  )
+}

--- a/src/components/viewport/SceneObject.tsx
+++ b/src/components/viewport/SceneObject.tsx
@@ -1,20 +1,13 @@
 import { useMemo, useState } from 'react'
-import type { Mesh, BufferGeometry } from 'three'
+import type { Mesh } from 'three'
 import { Edges } from '@react-three/drei'
-import type {
-  GridfinityObject,
-  GridfinityProfile,
-  Modifier,
-  ModifierContext,
-  BinParams,
-} from '@/types/gridfinity'
+import type { GridfinityObject, GridfinityProfile, Modifier, ModifierContext } from '@/types/gridfinity'
 import { generateBaseplate } from '@/engine/geometry/baseplate'
 import { generateBin } from '@/engine/geometry/bin'
-import { generateDividerGrid } from '@/engine/geometry/modifiers/dividerGrid'
-import { generateLabelTab } from '@/engine/geometry/modifiers/labelTab'
-import { generateScoop } from '@/engine/geometry/modifiers/scoop'
-import { generateInsert } from '@/engine/geometry/modifiers/insert'
-import { generateLid } from '@/engine/geometry/modifiers/lid'
+import {
+  generateModifierGeometry,
+  computeBinContext,
+} from '@/engine/export/mergeObjectGeometry'
 import { useProjectStore } from '@/store/projectStore'
 import { useProfileStore } from '@/store/profileStore'
 import { useUIStore } from '@/store/uiStore'
@@ -22,45 +15,6 @@ import { TransformGizmo } from './TransformGizmo'
 
 interface SceneObjectProps {
   object: GridfinityObject
-}
-
-function generateModifierGeometry(
-  modifier: Modifier,
-  context: ModifierContext,
-  profile: GridfinityProfile,
-): BufferGeometry | null {
-  switch (modifier.kind) {
-    case 'dividerGrid':
-      return generateDividerGrid(modifier.params, context, profile)
-    case 'labelTab':
-      return generateLabelTab(modifier.params, context, profile)
-    case 'scoop':
-      return generateScoop(modifier.params, context, profile)
-    case 'insert':
-      return generateInsert(modifier.params, context, profile)
-    case 'lid':
-      return generateLid(modifier.params, context, profile)
-  }
-}
-
-function computeBinContext(params: BinParams, profile: GridfinityProfile): ModifierContext {
-  const { gridWidth, gridDepth, heightUnits, wallThickness } = params
-  const { gridSize, heightUnit, tolerance, socketWallHeight } = profile
-
-  const outerWidth = gridWidth * gridSize - tolerance * 2
-  const outerDepth = gridDepth * gridSize - tolerance * 2
-  const innerWidth = outerWidth - wallThickness * 2
-  const innerDepth = outerDepth - wallThickness * 2
-  const wallHeight = heightUnits * heightUnit
-
-  return {
-    innerWidth,
-    innerDepth,
-    wallHeight,
-    floorY: socketWallHeight + wallThickness,
-    centerX: 0,
-    centerZ: 0,
-  }
 }
 
 interface ModifierMeshesProps {

--- a/src/engine/constants.ts
+++ b/src/engine/constants.ts
@@ -5,6 +5,7 @@ import type {
   ScoopModifierParams,
   InsertModifierParams,
   LidModifierParams,
+  PrintBedPreset,
 } from '@/types/gridfinity'
 
 export const PROFILE_OFFICIAL: GridfinityProfile = {
@@ -89,4 +90,10 @@ export const DEFAULT_INSERT_PARAMS: InsertModifierParams = {
 
 export const DEFAULT_LID_PARAMS: LidModifierParams = {
   stacking: false,
+}
+
+export const PRINT_BED_PRESETS: Record<string, PrintBedPreset> = {
+  '220x220': { name: '220 x 220 mm (Ender 3 / Prusa MK3)', width: 220, depth: 220 },
+  '256x256': { name: '256 x 256 mm (Bambu Lab A1/P1)', width: 256, depth: 256 },
+  '350x350': { name: '350 x 350 mm (Voron 350 / Large)', width: 350, depth: 350 },
 }

--- a/src/engine/export/__tests__/mergeObjectGeometry.test.ts
+++ b/src/engine/export/__tests__/mergeObjectGeometry.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest'
+import { mergeObjectWithModifiers, computeBinContext, generateModifierGeometry } from '../mergeObjectGeometry'
+import { PROFILE_OFFICIAL } from '../../constants'
+import type {
+  BaseplateObject,
+  BinObject,
+  Modifier,
+  DividerGridModifier,
+  LabelTabModifier,
+} from '@/types/gridfinity'
+
+function makeBin(overrides?: Partial<BinObject['params']>): BinObject {
+  return {
+    id: 'bin-1',
+    name: 'Test Bin',
+    kind: 'bin',
+    position: [0, 0, 0],
+    params: {
+      gridWidth: 1,
+      gridDepth: 1,
+      heightUnits: 3,
+      stackingLip: true,
+      wallThickness: 1.2,
+      innerFillet: 0,
+      ...overrides,
+    },
+  }
+}
+
+function makeBaseplate(): BaseplateObject {
+  return {
+    id: 'bp-1',
+    name: 'Test Baseplate',
+    kind: 'baseplate',
+    position: [0, 0, 0],
+    params: {
+      gridWidth: 1,
+      gridDepth: 1,
+      magnetHoles: false,
+      screwHoles: false,
+    },
+  }
+}
+
+describe('computeBinContext', () => {
+  it('computes inner dimensions for a 1x1 bin', () => {
+    const bin = makeBin()
+    const ctx = computeBinContext(bin.params, PROFILE_OFFICIAL)
+
+    expect(ctx.innerWidth).toBeGreaterThan(0)
+    expect(ctx.innerDepth).toBeGreaterThan(0)
+    expect(ctx.wallHeight).toBe(3 * 7) // 3 height units * 7mm
+    expect(ctx.floorY).toBeGreaterThan(0)
+  })
+
+  it('wider bins have larger inner width', () => {
+    const small = computeBinContext(makeBin({ gridWidth: 1 }).params, PROFILE_OFFICIAL)
+    const large = computeBinContext(makeBin({ gridWidth: 3 }).params, PROFILE_OFFICIAL)
+    expect(large.innerWidth).toBeGreaterThan(small.innerWidth)
+  })
+})
+
+describe('generateModifierGeometry', () => {
+  it('generates divider grid geometry', () => {
+    const bin = makeBin()
+    const ctx = computeBinContext(bin.params, PROFILE_OFFICIAL)
+    const modifier: DividerGridModifier = {
+      id: 'div-1',
+      parentId: 'bin-1',
+      kind: 'dividerGrid',
+      params: { dividersX: 1, dividersY: 1, wallThickness: 1.2 },
+    }
+    const geo = generateModifierGeometry(modifier, ctx, PROFILE_OFFICIAL)
+    expect(geo).toBeDefined()
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(geo!.attributes.position).toBeDefined()
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(geo!.attributes.position.count).toBeGreaterThan(0)
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    geo!.dispose()
+  })
+
+  it('generates label tab geometry', () => {
+    const bin = makeBin()
+    const ctx = computeBinContext(bin.params, PROFILE_OFFICIAL)
+    const modifier: LabelTabModifier = {
+      id: 'label-1',
+      parentId: 'bin-1',
+      kind: 'labelTab',
+      params: { wall: 'front', angle: 45, height: 7 },
+    }
+    const geo = generateModifierGeometry(modifier, ctx, PROFILE_OFFICIAL)
+    expect(geo).toBeDefined()
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(geo!.attributes.position.count).toBeGreaterThan(0)
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    geo!.dispose()
+  })
+})
+
+describe('mergeObjectWithModifiers', () => {
+  it('returns base geometry for baseplate with no modifiers', () => {
+    const bp = makeBaseplate()
+    const geo = mergeObjectWithModifiers(bp, [], PROFILE_OFFICIAL)
+    expect(geo).toBeDefined()
+    expect(geo.attributes.position).toBeDefined()
+    expect(geo.attributes.position.count).toBeGreaterThan(0)
+    geo.dispose()
+  })
+
+  it('returns base geometry for bin with no modifiers', () => {
+    const bin = makeBin()
+    const geo = mergeObjectWithModifiers(bin, [], PROFILE_OFFICIAL)
+    expect(geo).toBeDefined()
+    expect(geo.attributes.position.count).toBeGreaterThan(0)
+    geo.dispose()
+  })
+
+  it('merges bin with divider modifiers producing more vertices', () => {
+    const bin = makeBin()
+    const baseGeo = mergeObjectWithModifiers(bin, [], PROFILE_OFFICIAL)
+    const baseCount = baseGeo.attributes.position.count
+
+    const divider: DividerGridModifier = {
+      id: 'div-1',
+      parentId: 'bin-1',
+      kind: 'dividerGrid',
+      params: { dividersX: 1, dividersY: 1, wallThickness: 1.2 },
+    }
+    const mergedGeo = mergeObjectWithModifiers(bin, [divider], PROFILE_OFFICIAL)
+    expect(mergedGeo.attributes.position.count).toBeGreaterThan(baseCount)
+
+    baseGeo.dispose()
+    mergedGeo.dispose()
+  })
+
+  it('handles nested modifiers (divider with child label tab)', () => {
+    const bin = makeBin()
+    const divider: DividerGridModifier = {
+      id: 'div-1',
+      parentId: 'bin-1',
+      kind: 'dividerGrid',
+      params: { dividersX: 1, dividersY: 0, wallThickness: 1.2 },
+    }
+    const label: LabelTabModifier = {
+      id: 'label-1',
+      parentId: 'div-1',
+      kind: 'labelTab',
+      params: { wall: 'front', angle: 45, height: 7 },
+    }
+    const modifiers: Modifier[] = [divider, label]
+    const geo = mergeObjectWithModifiers(bin, modifiers, PROFILE_OFFICIAL)
+    expect(geo.attributes.position.count).toBeGreaterThan(0)
+    geo.dispose()
+  })
+})

--- a/src/engine/export/__tests__/printLayout.test.ts
+++ b/src/engine/export/__tests__/printLayout.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest'
+import { computePrintLayout, disposePrintLayout } from '../printLayout'
+import { PROFILE_OFFICIAL } from '../../constants'
+import type { BaseplateObject, BinObject, GridfinityObject } from '@/types/gridfinity'
+
+function makeBaseplate(id = 'bp-1'): BaseplateObject {
+  return {
+    id,
+    name: `Baseplate ${id}`,
+    kind: 'baseplate',
+    position: [0, 0, 0],
+    params: { gridWidth: 1, gridDepth: 1, magnetHoles: false, screwHoles: false },
+  }
+}
+
+function makeBin(id = 'bin-1'): BinObject {
+  return {
+    id,
+    name: `Bin ${id}`,
+    kind: 'bin',
+    position: [0, 0, 0],
+    params: {
+      gridWidth: 1,
+      gridDepth: 1,
+      heightUnits: 3,
+      stackingLip: true,
+      wallThickness: 1.2,
+      innerFillet: 0,
+    },
+  }
+}
+
+describe('computePrintLayout', () => {
+  it('returns empty array for no objects', () => {
+    const result = computePrintLayout([], [], PROFILE_OFFICIAL, 256, 256, 10)
+    expect(result).toEqual([])
+  })
+
+  it('lays out a single object on the bed', () => {
+    const objects: GridfinityObject[] = [makeBaseplate()]
+    const result = computePrintLayout(objects, [], PROFILE_OFFICIAL, 256, 256, 10)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].fitsOnBed).toBe(true)
+    expect(result[0].position[1]).toBe(0) // Y should be 0 (on bed)
+    expect(result[0].geometry).toBeDefined()
+    expect(result[0].geometry.attributes.position.count).toBeGreaterThan(0)
+
+    disposePrintLayout(result)
+  })
+
+  it('lays out multiple objects with spacing', () => {
+    const objects: GridfinityObject[] = [makeBaseplate('bp-1'), makeBin('bin-1')]
+    const result = computePrintLayout(objects, [], PROFILE_OFFICIAL, 256, 256, 10)
+
+    expect(result).toHaveLength(2)
+
+    // Objects should not overlap - their X positions + half-widths should not intersect
+    const [a, b] = result
+    const aRight = a.position[0] + a.boundingBox.width / 2
+    const bLeft = b.position[0] - b.boundingBox.width / 2
+    expect(bLeft).toBeGreaterThanOrEqual(aRight - 0.01) // allow floating point tolerance
+
+    disposePrintLayout(result)
+  })
+
+  it('marks objects that exceed bed bounds', () => {
+    // Use a very small bed
+    const objects: GridfinityObject[] = [makeBaseplate()]
+    const result = computePrintLayout(objects, [], PROFILE_OFFICIAL, 10, 10, 5)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].fitsOnBed).toBe(false)
+
+    disposePrintLayout(result)
+  })
+
+  it('all objects fit on a large bed', () => {
+    const objects: GridfinityObject[] = [
+      makeBaseplate('bp-1'),
+      makeBaseplate('bp-2'),
+      makeBin('bin-1'),
+    ]
+    const result = computePrintLayout(objects, [], PROFILE_OFFICIAL, 350, 350, 10)
+
+    expect(result).toHaveLength(3)
+    expect(result.every((item) => item.fitsOnBed)).toBe(true)
+
+    disposePrintLayout(result)
+  })
+
+  it('wraps to next row when objects exceed bed width', () => {
+    // 5 baseplates on a 256mm bed (each ~42mm wide, so 5 baseplates + spacing > 256)
+    const objects: GridfinityObject[] = Array.from({ length: 5 }, (_, i) =>
+      makeBaseplate(`bp-${i}`),
+    )
+    const result = computePrintLayout(objects, [], PROFILE_OFFICIAL, 200, 200, 10)
+
+    // At least some should have different Z positions (different rows)
+    const zPositions = new Set(result.map((r) => Math.round(r.position[2])))
+    expect(zPositions.size).toBeGreaterThan(1)
+
+    disposePrintLayout(result)
+  })
+
+  it('provides bounding box dimensions for each item', () => {
+    const objects: GridfinityObject[] = [makeBin()]
+    const result = computePrintLayout(objects, [], PROFILE_OFFICIAL, 256, 256, 10)
+
+    expect(result[0].boundingBox.width).toBeGreaterThan(0)
+    expect(result[0].boundingBox.depth).toBeGreaterThan(0)
+    expect(result[0].boundingBox.height).toBeGreaterThan(0)
+
+    disposePrintLayout(result)
+  })
+})

--- a/src/engine/export/__tests__/printOrientation.test.ts
+++ b/src/engine/export/__tests__/printOrientation.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest'
+import * as THREE from 'three'
+import { getPrintRotation, getOrientedBounds, applyPrintOrientation } from '../printOrientation'
+import { generateBaseplate } from '../../geometry/baseplate'
+import { generateBin } from '../../geometry/bin'
+import { PROFILE_OFFICIAL } from '../../constants'
+import type { BaseplateObject, BinObject } from '@/types/gridfinity'
+
+function makeBaseplate(): BaseplateObject {
+  return {
+    id: 'bp-1',
+    name: 'Test Baseplate',
+    kind: 'baseplate',
+    position: [0, 0, 0],
+    params: { gridWidth: 1, gridDepth: 1, magnetHoles: false, screwHoles: false },
+  }
+}
+
+function makeBin(): BinObject {
+  return {
+    id: 'bin-1',
+    name: 'Test Bin',
+    kind: 'bin',
+    position: [0, 0, 0],
+    params: {
+      gridWidth: 1,
+      gridDepth: 1,
+      heightUnits: 3,
+      stackingLip: true,
+      wallThickness: 1.2,
+      innerFillet: 0,
+    },
+  }
+}
+
+describe('getPrintRotation', () => {
+  it('returns identity rotation for baseplates', () => {
+    const bp = makeBaseplate()
+    const rotation = getPrintRotation(bp)
+    expect(rotation.x).toBe(0)
+    expect(rotation.y).toBe(0)
+    expect(rotation.z).toBe(0)
+  })
+
+  it('returns 180-degree X rotation for bins', () => {
+    const bin = makeBin()
+    const rotation = getPrintRotation(bin)
+    expect(rotation.x).toBeCloseTo(Math.PI, 5)
+    expect(rotation.y).toBe(0)
+    expect(rotation.z).toBe(0)
+  })
+})
+
+describe('getOrientedBounds', () => {
+  it('returns positive dimensions for baseplate', () => {
+    const bp = makeBaseplate()
+    const geo = generateBaseplate(bp.params, PROFILE_OFFICIAL)
+    const rotation = getPrintRotation(bp)
+    const bounds = getOrientedBounds(geo, rotation)
+
+    expect(bounds.width).toBeGreaterThan(0)
+    expect(bounds.depth).toBeGreaterThan(0)
+    expect(bounds.height).toBeGreaterThan(0)
+    expect(bounds.yOffset).toBeGreaterThanOrEqual(0)
+
+    geo.dispose()
+  })
+
+  it('returns correct bounds for rotated bin', () => {
+    const bin = makeBin()
+    const geo = generateBin(bin.params, PROFILE_OFFICIAL)
+    const rotation = getPrintRotation(bin)
+    const bounds = getOrientedBounds(geo, rotation)
+
+    expect(bounds.width).toBeGreaterThan(30) // approx 1 grid unit
+    expect(bounds.depth).toBeGreaterThan(30)
+    expect(bounds.height).toBeGreaterThan(10) // bin has height
+
+    geo.dispose()
+  })
+})
+
+describe('applyPrintOrientation', () => {
+  it('baseplate min Y is approximately 0 after orientation', () => {
+    const bp = makeBaseplate()
+    const geo = generateBaseplate(bp.params, PROFILE_OFFICIAL)
+    const rotation = getPrintRotation(bp)
+    const oriented = applyPrintOrientation(geo, rotation)
+
+    oriented.computeBoundingBox()
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const box = oriented.boundingBox!
+    expect(box.min.y).toBeCloseTo(0, 2)
+
+    geo.dispose()
+    oriented.dispose()
+  })
+
+  it('bin min Y is approximately 0 after orientation (flipped)', () => {
+    const bin = makeBin()
+    const geo = generateBin(bin.params, PROFILE_OFFICIAL)
+    const rotation = getPrintRotation(bin)
+    const oriented = applyPrintOrientation(geo, rotation)
+
+    oriented.computeBoundingBox()
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const box = oriented.boundingBox!
+    expect(box.min.y).toBeCloseTo(0, 2)
+    expect(box.max.y).toBeGreaterThan(0)
+
+    geo.dispose()
+    oriented.dispose()
+  })
+
+  it('does not modify the original geometry', () => {
+    const bin = makeBin()
+    const geo = generateBin(bin.params, PROFILE_OFFICIAL)
+    geo.computeBoundingBox()
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const originalMinY = geo.boundingBox!.min.y
+
+    const rotation = new THREE.Euler(Math.PI, 0, 0)
+    const oriented = applyPrintOrientation(geo, rotation)
+
+    geo.computeBoundingBox()
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(geo.boundingBox!.min.y).toBeCloseTo(originalMinY, 5)
+
+    geo.dispose()
+    oriented.dispose()
+  })
+})

--- a/src/engine/export/__tests__/stlExporter.test.ts
+++ b/src/engine/export/__tests__/stlExporter.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import * as THREE from 'three'
+import { exportObjectAsSTL, exportAllAsSingleSTL } from '../stlExporter'
+import { generateBaseplate } from '../../geometry/baseplate'
+import { PROFILE_OFFICIAL } from '../../constants'
+import type { PrintLayoutItem } from '../printLayout'
+import type { BaseplateObject } from '@/types/gridfinity'
+
+// Track download calls via a shared state object
+let downloadState: { triggered: boolean; filename: string }
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  downloadState = { triggered: false, filename: '' }
+
+  vi.stubGlobal('URL', {
+    ...globalThis.URL,
+    createObjectURL: vi.fn(() => 'blob:mock-url'),
+    revokeObjectURL: vi.fn(),
+  })
+
+  const mockLink = {
+    href: '',
+    download: '',
+    click: () => {
+      downloadState.triggered = true
+      downloadState.filename = mockLink.download
+    },
+  }
+  vi.spyOn(document, 'createElement').mockReturnValue(mockLink as unknown as HTMLElement)
+  vi.spyOn(document.body, 'appendChild').mockImplementation(() => mockLink as unknown as Node)
+  vi.spyOn(document.body, 'removeChild').mockImplementation(() => mockLink as unknown as Node)
+})
+
+function makeTestGeometry(): THREE.BufferGeometry {
+  const geometry = new THREE.BufferGeometry()
+  const vertices = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0])
+  const normals = new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1])
+  geometry.setAttribute('position', new THREE.BufferAttribute(vertices, 3))
+  geometry.setAttribute('normal', new THREE.BufferAttribute(normals, 3))
+  geometry.setIndex([0, 1, 2])
+  return geometry
+}
+
+describe('exportObjectAsSTL', () => {
+  it('triggers a download with .stl extension', () => {
+    const geo = makeTestGeometry()
+    exportObjectAsSTL(geo, 'test-object')
+
+    expect(downloadState.triggered).toBe(true)
+    expect(downloadState.filename).toBe('test-object.stl')
+
+    geo.dispose()
+  })
+
+  it('sanitizes filenames with special characters', () => {
+    const geo = makeTestGeometry()
+    exportObjectAsSTL(geo, 'my/object<name>')
+
+    expect(downloadState.filename).toBe('my_object_name_.stl')
+
+    geo.dispose()
+  })
+
+  it('handles real baseplate geometry', () => {
+    const params = { gridWidth: 1, gridDepth: 1, magnetHoles: false, screwHoles: false }
+    const geo = generateBaseplate(params, PROFILE_OFFICIAL)
+
+    expect(() => {
+      exportObjectAsSTL(geo, 'Baseplate')
+    }).not.toThrow()
+
+    geo.dispose()
+  })
+})
+
+describe('exportAllAsSingleSTL', () => {
+  it('does nothing with empty items', () => {
+    exportAllAsSingleSTL([])
+    expect(downloadState.triggered).toBe(false)
+  })
+
+  it('exports merged geometry from multiple items', () => {
+    const bp: BaseplateObject = {
+      id: 'bp-1',
+      name: 'Baseplate 1',
+      kind: 'baseplate',
+      position: [0, 0, 0],
+      params: { gridWidth: 1, gridDepth: 1, magnetHoles: false, screwHoles: false },
+    }
+
+    const items: PrintLayoutItem[] = [
+      {
+        object: bp,
+        geometry: makeTestGeometry(),
+        position: [0, 0, 0],
+        boundingBox: { width: 42, depth: 42, height: 7 },
+        fitsOnBed: true,
+      },
+      {
+        object: { ...bp, id: 'bp-2', name: 'Baseplate 2' },
+        geometry: makeTestGeometry(),
+        position: [52, 0, 0],
+        boundingBox: { width: 42, depth: 42, height: 7 },
+        fitsOnBed: true,
+      },
+    ]
+
+    expect(() => {
+      exportAllAsSingleSTL(items)
+    }).not.toThrow()
+    expect(downloadState.triggered).toBe(true)
+    expect(downloadState.filename).toBe('react-finity-plate.stl')
+
+    for (const item of items) {
+      item.geometry.dispose()
+    }
+  })
+})

--- a/src/engine/export/mergeObjectGeometry.ts
+++ b/src/engine/export/mergeObjectGeometry.ts
@@ -1,0 +1,161 @@
+import type { BufferGeometry } from 'three'
+import type {
+  GridfinityObject,
+  GridfinityProfile,
+  Modifier,
+  ModifierContext,
+  BinParams,
+} from '@/types/gridfinity'
+import { generateBaseplate } from '@/engine/geometry/baseplate'
+import { generateBin } from '@/engine/geometry/bin'
+import { generateDividerGrid } from '@/engine/geometry/modifiers/dividerGrid'
+import { generateLabelTab } from '@/engine/geometry/modifiers/labelTab'
+import { generateScoop } from '@/engine/geometry/modifiers/scoop'
+import { generateInsert } from '@/engine/geometry/modifiers/insert'
+import { generateLid } from '@/engine/geometry/modifiers/lid'
+import { mergeGeometries } from '@/engine/geometry/primitives'
+
+export function generateModifierGeometry(
+  modifier: Modifier,
+  context: ModifierContext,
+  profile: GridfinityProfile,
+): BufferGeometry | null {
+  switch (modifier.kind) {
+    case 'dividerGrid':
+      return generateDividerGrid(modifier.params, context, profile)
+    case 'labelTab':
+      return generateLabelTab(modifier.params, context, profile)
+    case 'scoop':
+      return generateScoop(modifier.params, context, profile)
+    case 'insert':
+      return generateInsert(modifier.params, context, profile)
+    case 'lid':
+      return generateLid(modifier.params, context, profile)
+  }
+}
+
+export function computeBinContext(params: BinParams, profile: GridfinityProfile): ModifierContext {
+  const { gridWidth, gridDepth, heightUnits, wallThickness } = params
+  const { gridSize, heightUnit, tolerance, socketWallHeight } = profile
+
+  const outerWidth = gridWidth * gridSize - tolerance * 2
+  const outerDepth = gridDepth * gridSize - tolerance * 2
+  const innerWidth = outerWidth - wallThickness * 2
+  const innerDepth = outerDepth - wallThickness * 2
+  const wallHeight = heightUnits * heightUnit
+
+  return {
+    innerWidth,
+    innerDepth,
+    wallHeight,
+    floorY: socketWallHeight + wallThickness,
+    centerX: 0,
+    centerZ: 0,
+  }
+}
+
+function computeChildContext(modifier: Modifier, parentContext: ModifierContext): ModifierContext {
+  if (modifier.kind === 'dividerGrid') {
+    const { dividersX, dividersY, wallThickness } = modifier.params
+    if (dividersX === 0 && dividersY === 0) return parentContext
+    const compartmentWidth =
+      (parentContext.innerWidth - wallThickness * dividersX) / (dividersX + 1)
+    const compartmentDepth =
+      (parentContext.innerDepth - wallThickness * dividersY) / (dividersY + 1)
+    return {
+      innerWidth: compartmentWidth,
+      innerDepth: compartmentDepth,
+      wallHeight: parentContext.wallHeight,
+      floorY: parentContext.floorY,
+      centerX: parentContext.centerX,
+      centerZ: parentContext.centerZ,
+    }
+  }
+  if (modifier.kind === 'insert') {
+    const { compartmentsX, compartmentsY, wallThickness } = modifier.params
+    const rimInnerWidth = parentContext.innerWidth - wallThickness * 2
+    const rimInnerDepth = parentContext.innerDepth - wallThickness * 2
+    const compartmentWidth =
+      (rimInnerWidth - wallThickness * (compartmentsX - 1)) / compartmentsX
+    const compartmentDepth =
+      (rimInnerDepth - wallThickness * (compartmentsY - 1)) / compartmentsY
+    return {
+      innerWidth: compartmentWidth,
+      innerDepth: compartmentDepth,
+      wallHeight: parentContext.wallHeight,
+      floorY: parentContext.floorY,
+      centerX: parentContext.centerX,
+      centerZ: parentContext.centerZ,
+    }
+  }
+  return parentContext
+}
+
+function collectModifierGeometries(
+  parentId: string,
+  context: ModifierContext,
+  allModifiers: Modifier[],
+  profile: GridfinityProfile,
+): BufferGeometry[] {
+  const children = allModifiers.filter((m) => m.parentId === parentId)
+  const geometries: BufferGeometry[] = []
+
+  for (const modifier of children) {
+    const geo = generateModifierGeometry(modifier, context, profile)
+    if (geo && 'position' in geo.attributes) {
+      geometries.push(geo)
+    }
+
+    const childContext = computeChildContext(modifier, context)
+    const childGeos = collectModifierGeometries(modifier.id, childContext, allModifiers, profile)
+    geometries.push(...childGeos)
+  }
+
+  return geometries
+}
+
+function generateObjectGeometry(
+  object: GridfinityObject,
+  profile: GridfinityProfile,
+): BufferGeometry {
+  switch (object.kind) {
+    case 'baseplate':
+      return generateBaseplate(object.params, profile)
+    case 'bin':
+      return generateBin(object.params, profile)
+  }
+}
+
+/**
+ * Merge an object with all its modifiers into a single BufferGeometry.
+ * The result includes the base object geometry plus all modifier geometries
+ * recursively collected and merged.
+ */
+export function mergeObjectWithModifiers(
+  object: GridfinityObject,
+  modifiers: Modifier[],
+  profile: GridfinityProfile,
+): BufferGeometry {
+  const baseGeometry = generateObjectGeometry(object, profile)
+
+  if (object.kind !== 'bin') {
+    return baseGeometry
+  }
+
+  const context = computeBinContext(object.params, profile)
+  const modifierGeometries = collectModifierGeometries(object.id, context, modifiers, profile)
+
+  if (modifierGeometries.length === 0) {
+    return baseGeometry
+  }
+
+  const allGeometries = [baseGeometry, ...modifierGeometries]
+  const merged = mergeGeometries(allGeometries)
+
+  baseGeometry.dispose()
+  for (const geo of modifierGeometries) {
+    geo.dispose()
+  }
+
+  return merged
+}

--- a/src/engine/export/printLayout.ts
+++ b/src/engine/export/printLayout.ts
@@ -1,0 +1,98 @@
+import type { BufferGeometry } from 'three'
+import type { GridfinityObject, GridfinityProfile, Modifier } from '@/types/gridfinity'
+import { mergeObjectWithModifiers } from './mergeObjectGeometry'
+import { getPrintRotation, getOrientedBounds, applyPrintOrientation } from './printOrientation'
+
+export interface PrintLayoutItem {
+  object: GridfinityObject
+  geometry: BufferGeometry
+  position: [number, number, number]
+  boundingBox: { width: number; depth: number; height: number }
+  fitsOnBed: boolean
+}
+
+/**
+ * Compute a print layout: merge each object with its modifiers, orient for
+ * FDM printing, and arrange on a virtual print bed using row-based packing.
+ *
+ * Objects are sorted by depth (largest first) and placed in rows from
+ * the front-left corner. Objects that exceed bed bounds in either axis
+ * are still included but flagged with fitsOnBed = false.
+ */
+export function computePrintLayout(
+  objects: GridfinityObject[],
+  modifiers: Modifier[],
+  profile: GridfinityProfile,
+  bedWidth: number,
+  bedDepth: number,
+  spacing: number,
+): PrintLayoutItem[] {
+  if (objects.length === 0) return []
+
+  // Generate merged + oriented geometries and measure bounding boxes
+  const items: {
+    object: GridfinityObject
+    geometry: BufferGeometry
+    bounds: { width: number; depth: number; height: number }
+  }[] = []
+
+  for (const obj of objects) {
+    const merged = mergeObjectWithModifiers(obj, modifiers, profile)
+    const rotation = getPrintRotation(obj)
+    const oriented = applyPrintOrientation(merged, rotation)
+    const bounds = getOrientedBounds(merged, rotation)
+    merged.dispose()
+    items.push({ object: obj, geometry: oriented, bounds })
+  }
+
+  // Sort by depth descending for better row packing
+  items.sort((a, b) => b.bounds.depth - a.bounds.depth)
+
+  // Row-based packing
+  const result: PrintLayoutItem[] = []
+  let currentX = 0
+  let currentZ = 0
+  let rowMaxDepth = 0
+
+  for (const item of items) {
+    const { bounds } = item
+
+    // Check if the item fits in the current row
+    if (currentX + bounds.width > bedWidth && currentX > 0) {
+      // Move to next row
+      currentZ += rowMaxDepth + spacing
+      currentX = 0
+      rowMaxDepth = 0
+    }
+
+    // Center the object within its bounding box position:
+    // position is the center-bottom of the object on the bed
+    const posX = currentX + bounds.width / 2
+    const posZ = currentZ + bounds.depth / 2
+
+    const fitsOnBed =
+      currentX + bounds.width <= bedWidth && currentZ + bounds.depth <= bedDepth
+
+    result.push({
+      object: item.object,
+      geometry: item.geometry,
+      position: [posX, 0, posZ],
+      boundingBox: bounds,
+      fitsOnBed,
+    })
+
+    currentX += bounds.width + spacing
+    rowMaxDepth = Math.max(rowMaxDepth, bounds.depth)
+  }
+
+  return result
+}
+
+/**
+ * Dispose all geometries in a print layout result.
+ */
+export function disposePrintLayout(items: PrintLayoutItem[]): void {
+  for (const item of items) {
+    item.geometry.dispose()
+  }
+}

--- a/src/engine/export/printOrientation.ts
+++ b/src/engine/export/printOrientation.ts
@@ -1,0 +1,69 @@
+import * as THREE from 'three'
+import type { GridfinityObject } from '@/types/gridfinity'
+
+/**
+ * Get the optimal print rotation for an object kind.
+ *
+ * - Baseplates: no rotation (flat bottom already faces down)
+ * - Bins: 180 degrees around X axis (flip upside-down so the open top
+ *   faces the print bed and the flat bottom faces up, avoiding internal
+ *   cavity overhangs for FDM printing)
+ */
+export function getPrintRotation(object: GridfinityObject): THREE.Euler {
+  switch (object.kind) {
+    case 'baseplate':
+      return new THREE.Euler(0, 0, 0)
+    case 'bin':
+      return new THREE.Euler(Math.PI, 0, 0)
+  }
+}
+
+/**
+ * Compute the bounding box of a geometry after applying a rotation,
+ * then translate so the minimum Y sits at 0 (on the print bed).
+ *
+ * Returns { box, yOffset } where yOffset is the translation needed.
+ */
+export function getOrientedBounds(
+  geometry: THREE.BufferGeometry,
+  rotation: THREE.Euler,
+): { width: number; depth: number; height: number; yOffset: number } {
+  const clone = geometry.clone()
+  const matrix = new THREE.Matrix4().makeRotationFromEuler(rotation)
+  clone.applyMatrix4(matrix)
+  clone.computeBoundingBox()
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const box = clone.boundingBox!
+
+  const width = box.max.x - box.min.x
+  const depth = box.max.z - box.min.z
+  const height = box.max.y - box.min.y
+  const yOffset = -box.min.y
+
+  clone.dispose()
+
+  return { width, depth, height, yOffset }
+}
+
+/**
+ * Apply print orientation to a geometry: rotate and translate so it
+ * sits flat on the print bed (min Y = 0).
+ *
+ * Returns a new geometry; the original is not modified.
+ */
+export function applyPrintOrientation(
+  geometry: THREE.BufferGeometry,
+  rotation: THREE.Euler,
+): THREE.BufferGeometry {
+  const oriented = geometry.clone()
+  const rotMatrix = new THREE.Matrix4().makeRotationFromEuler(rotation)
+  oriented.applyMatrix4(rotMatrix)
+  oriented.computeBoundingBox()
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const minY = oriented.boundingBox!.min.y
+  if (Math.abs(minY) > 0.001) {
+    const translateMatrix = new THREE.Matrix4().makeTranslation(0, -minY, 0)
+    oriented.applyMatrix4(translateMatrix)
+  }
+  return oriented
+}

--- a/src/engine/export/stlExporter.ts
+++ b/src/engine/export/stlExporter.ts
@@ -1,0 +1,135 @@
+import * as THREE from 'three'
+import { STLExporter } from 'three/addons/exporters/STLExporter.js'
+import JSZip from 'jszip'
+import type { PrintLayoutItem } from './printLayout'
+
+function sanitizeFilename(name: string): string {
+  return name.replace(/[^a-zA-Z0-9_\-. ]/g, '_').trim() || 'object'
+}
+
+function geometryToSTLBinary(geometry: THREE.BufferGeometry): ArrayBuffer {
+  const exporter = new STLExporter()
+  const mesh = new THREE.Mesh(geometry, new THREE.MeshBasicMaterial())
+  const result = exporter.parse(mesh, { binary: true }) as DataView
+  // Copy to a plain ArrayBuffer to satisfy BlobPart/JSZip type constraints
+  const arrayBuffer = new ArrayBuffer(result.byteLength)
+  new Uint8Array(arrayBuffer).set(new Uint8Array(result.buffer as ArrayBuffer))
+  return arrayBuffer
+}
+
+function triggerDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = filename
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(url)
+}
+
+/**
+ * Export a single geometry as a binary STL file download.
+ */
+export function exportObjectAsSTL(geometry: THREE.BufferGeometry, name: string): void {
+  const buffer = geometryToSTLBinary(geometry)
+  const blob = new Blob([buffer], { type: 'application/octet-stream' })
+  triggerDownload(blob, `${sanitizeFilename(name)}.stl`)
+}
+
+/**
+ * Export all print layout items as individual STL files bundled in a ZIP.
+ */
+export async function exportAllAsZip(items: PrintLayoutItem[]): Promise<void> {
+  const zip = new JSZip()
+
+  for (const item of items) {
+    const data = geometryToSTLBinary(item.geometry)
+    const filename = `${sanitizeFilename(item.object.name)}.stl`
+    zip.file(filename, data)
+  }
+
+  const blob = await zip.generateAsync({ type: 'blob' })
+  triggerDownload(blob, 'react-finity-export.zip')
+}
+
+/**
+ * Export all print layout items as a single merged STL with objects at
+ * their layout positions.
+ */
+export function exportAllAsSingleSTL(items: PrintLayoutItem[]): void {
+  if (items.length === 0) return
+
+  const geometries: THREE.BufferGeometry[] = []
+
+  for (const item of items) {
+    const clone = item.geometry.clone()
+    const [x, y, z] = item.position
+    clone.translate(x, y, z)
+    geometries.push(clone)
+  }
+
+  // Merge all positioned geometries
+  const merged = new THREE.BufferGeometry()
+  let totalVertices = 0
+  let totalIndices = 0
+
+  for (const geo of geometries) {
+    totalVertices += geo.attributes.position.count
+    if (geo.index) {
+      totalIndices += geo.index.count
+    } else {
+      totalIndices += geo.attributes.position.count
+    }
+  }
+
+  const positions = new Float32Array(totalVertices * 3)
+  const normals = new Float32Array(totalVertices * 3)
+  const indices = new Uint32Array(totalIndices)
+
+  let vertexOffset = 0
+  let indexOffset = 0
+
+  for (const geo of geometries) {
+    const posAttr = geo.attributes.position as THREE.BufferAttribute
+    const normAttr = geo.attributes.normal as THREE.BufferAttribute | undefined
+
+    for (let i = 0; i < posAttr.count * 3; i++) {
+      positions[vertexOffset * 3 + i] = posAttr.array[i]
+    }
+
+    if (normAttr) {
+      for (let i = 0; i < normAttr.count * 3; i++) {
+        normals[vertexOffset * 3 + i] = normAttr.array[i]
+      }
+    }
+
+    if (geo.index) {
+      for (let i = 0; i < geo.index.count; i++) {
+        indices[indexOffset + i] = geo.index.array[i] + vertexOffset
+      }
+      indexOffset += geo.index.count
+    } else {
+      for (let i = 0; i < posAttr.count; i++) {
+        indices[indexOffset + i] = vertexOffset + i
+      }
+      indexOffset += posAttr.count
+    }
+
+    vertexOffset += posAttr.count
+  }
+
+  merged.setAttribute('position', new THREE.BufferAttribute(positions, 3))
+  merged.setAttribute('normal', new THREE.BufferAttribute(normals, 3))
+  merged.setIndex(new THREE.BufferAttribute(indices, 1))
+  merged.computeVertexNormals()
+
+  const buffer = geometryToSTLBinary(merged)
+  const blob = new Blob([buffer], { type: 'application/octet-stream' })
+  triggerDownload(blob, 'react-finity-plate.stl')
+
+  merged.dispose()
+  for (const geo of geometries) {
+    geo.dispose()
+  }
+}

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,6 +1,10 @@
 import { useEffect } from 'react'
 import { useProjectStore } from '@/store/projectStore'
+import { useProfileStore } from '@/store/profileStore'
 import { useUIStore } from '@/store/uiStore'
+import { mergeObjectWithModifiers } from '@/engine/export/mergeObjectGeometry'
+import { getPrintRotation, applyPrintOrientation } from '@/engine/export/printOrientation'
+import { exportObjectAsSTL } from '@/engine/export/stlExporter'
 
 export function useKeyboardShortcuts() {
   const removeObject = useProjectStore((s) => s.removeObject)
@@ -29,6 +33,32 @@ export function useKeyboardShortcuts() {
 
       if (e.key === 'Escape') {
         selectObject(null)
+      }
+
+      // Ctrl+Shift+E: Export selected object as STL
+      if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'E') {
+        e.preventDefault()
+        if (selectedObjectId) {
+          const objects = useProjectStore.getState().objects
+          const modifiers = useProjectStore.getState().modifiers
+          const profile = useProfileStore.getState().activeProfile
+          const obj = objects.find((o) => o.id === selectedObjectId)
+          if (obj) {
+            const merged = mergeObjectWithModifiers(obj, modifiers, profile)
+            const rotation = getPrintRotation(obj)
+            const oriented = applyPrintOrientation(merged, rotation)
+            exportObjectAsSTL(oriented, obj.name)
+            merged.dispose()
+            oriented.dispose()
+          }
+        }
+      }
+
+      // Ctrl+P: Toggle print layout view
+      if ((e.ctrlKey || e.metaKey) && e.key === 'p') {
+        e.preventDefault()
+        const { activeView, setActiveView } = useUIStore.getState()
+        setActiveView(activeView === 'edit' ? 'printLayout' : 'edit')
       }
     }
 

--- a/src/store/__tests__/uiStore.test.ts
+++ b/src/store/__tests__/uiStore.test.ts
@@ -12,6 +12,9 @@ describe('uiStore', () => {
       cameraPreset: null,
       snapToGrid: true,
       showMeasurements: true,
+      activeView: 'edit',
+      printBedPreset: '256x256',
+      printBedSpacing: 10,
     })
   })
 
@@ -105,5 +108,29 @@ describe('uiStore', () => {
     expect(useUIStore.getState().showMeasurements).toBe(false)
     useUIStore.getState().toggleShowMeasurements()
     expect(useUIStore.getState().showMeasurements).toBe(true)
+  })
+
+  it('sets active view', () => {
+    expect(useUIStore.getState().activeView).toBe('edit')
+    useUIStore.getState().setActiveView('printLayout')
+    expect(useUIStore.getState().activeView).toBe('printLayout')
+    useUIStore.getState().setActiveView('edit')
+    expect(useUIStore.getState().activeView).toBe('edit')
+  })
+
+  it('sets print bed preset', () => {
+    expect(useUIStore.getState().printBedPreset).toBe('256x256')
+    useUIStore.getState().setPrintBedPreset('220x220')
+    expect(useUIStore.getState().printBedPreset).toBe('220x220')
+    useUIStore.getState().setPrintBedPreset('350x350')
+    expect(useUIStore.getState().printBedPreset).toBe('350x350')
+  })
+
+  it('sets print bed spacing', () => {
+    expect(useUIStore.getState().printBedSpacing).toBe(10)
+    useUIStore.getState().setPrintBedSpacing(15)
+    expect(useUIStore.getState().printBedSpacing).toBe(15)
+    useUIStore.getState().setPrintBedSpacing(5)
+    expect(useUIStore.getState().printBedSpacing).toBe(5)
   })
 })

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -1,5 +1,10 @@
 import { create } from 'zustand'
-import type { ViewportBackground, LightingPreset, CameraPreset } from '@/types/gridfinity'
+import type {
+  ViewportBackground,
+  LightingPreset,
+  CameraPreset,
+  AppView,
+} from '@/types/gridfinity'
 
 interface UIStore {
   selectedObjectId: string | null
@@ -10,6 +15,9 @@ interface UIStore {
   cameraPreset: CameraPreset | null
   snapToGrid: boolean
   showMeasurements: boolean
+  activeView: AppView
+  printBedPreset: string
+  printBedSpacing: number
   selectObject: (id: string | null) => void
   toggleLeftPanel: () => void
   toggleRightPanel: () => void
@@ -20,6 +28,9 @@ interface UIStore {
   setCameraPreset: (preset: CameraPreset | null) => void
   toggleSnapToGrid: () => void
   toggleShowMeasurements: () => void
+  setActiveView: (view: AppView) => void
+  setPrintBedPreset: (key: string) => void
+  setPrintBedSpacing: (spacing: number) => void
 }
 
 export const useUIStore = create<UIStore>()((set) => ({
@@ -31,6 +42,9 @@ export const useUIStore = create<UIStore>()((set) => ({
   cameraPreset: null,
   snapToGrid: true,
   showMeasurements: true,
+  activeView: 'edit',
+  printBedPreset: '256x256',
+  printBedSpacing: 10,
 
   selectObject: (id) => {
     set({ selectedObjectId: id })
@@ -70,5 +84,17 @@ export const useUIStore = create<UIStore>()((set) => ({
 
   toggleShowMeasurements: () => {
     set((state) => ({ showMeasurements: !state.showMeasurements }))
+  },
+
+  setActiveView: (view) => {
+    set({ activeView: view })
+  },
+
+  setPrintBedPreset: (key) => {
+    set({ printBedPreset: key })
+  },
+
+  setPrintBedSpacing: (spacing) => {
+    set({ printBedSpacing: spacing })
   },
 }))

--- a/src/types/gridfinity.ts
+++ b/src/types/gridfinity.ts
@@ -132,3 +132,13 @@ export type Modifier =
 export type ViewportBackground = 'dark' | 'light' | 'neutral'
 export type LightingPreset = 'studio' | 'outdoor' | 'soft'
 export type CameraPreset = 'top' | 'front' | 'side' | 'isometric'
+
+// --- View mode ---
+
+export type AppView = 'edit' | 'printLayout'
+
+export interface PrintBedPreset {
+  name: string
+  width: number // mm
+  depth: number // mm
+}


### PR DESCRIPTION
## Summary

This PR adds a complete print layout and export system to React-Finity, enabling users to visualize objects on a virtual print bed and export them as STL files for 3D printing.

## Key Changes

### New Print Layout View
- Added dedicated **Print Layout view** mode accessible via toolbar toggle (Edit/Print) or Ctrl+P keyboard shortcut
- Implemented `PrintLayoutViewport` component with 3D visualization of a virtual print bed with grid overlay
- Objects are displayed at their arranged positions with color coding (gray = fits, red = exceeds bed bounds)

### Print Settings Panel
- New `PrintSettingsPanel` component with:
  - Bed size selector (multiple presets: 256×256, 300×300, etc.)
  - Object spacing slider (5–30 mm)
  - Object list with individual export buttons
  - Batch export options (ZIP or single merged STL)

### Export System
- **STL Export**: Binary STL export via Three.js STLExporter for individual objects or entire layouts
- **Batch Export**: 
  - Export all objects as individual STL files in a ZIP archive
  - Export all objects as a single merged STL with correct positioning
- **Keyboard Shortcut**: Ctrl+E exports the currently selected object
- **Toolbar Integration**: Export dropdown menu with "Export Selected" and "Open Print Layout" options

### Print Layout Algorithm
- Implemented `computePrintLayout()` function that:
  - Merges each object with its modifiers
  - Applies optimal print orientation (baseplates flat, bins flipped for FDM)
  - Arranges objects on virtual bed using row-based packing
  - Flags objects that exceed bed bounds
- Added `mergeObjectWithModifiers()` to recursively generate and merge modifier geometries
- Added `applyPrintOrientation()` to rotate and position objects for printing

### Refactoring
- Extracted modifier geometry generation logic from `SceneObject` into `mergeObjectGeometry.ts` for reuse
- Updated `SceneObject` to use the new shared functions

### UI Store Updates
- Added `activeView` state to track Edit vs. Print Layout mode
- Added `printBedPreset` and `printBedSpacing` state for print settings
- Added `setActiveView()`, `setPrintBedPreset()`, and `setPrintBedSpacing()` actions

### Testing
- Added comprehensive unit tests for:
  - `mergeObjectGeometry` (modifier context computation, geometry generation)
  - `printOrientation` (rotation logic, bounds calculation)
  - `printLayout` (packing algorithm, fit detection)
  - `stlExporter` (filename sanitization, download triggering)
- Added E2E tests for print layout view switching and export functionality

### Documentation
- Updated ROADMAP.md to reflect Phase 5 completion (export & print layout)
- Updated README.md with print layout feature description
- Updated CLAUDE.md with new file structure

## Implementation Details

- **Print Bed Presets**: Configurable via `PRINT_BED_PRESETS` constant with standard FDM printer bed sizes
- **Geometry Disposal**: Proper cleanup of Three.js geometries to prevent memory leaks
- **Filename Sanitization**: Special characters in object names are replaced with underscores for safe file exports
- **Row-Based Packing**: Objects sorted by depth (largest first) and placed in rows for efficient bed utilization
- **Print Orientation**: Bins are flipped 180° around X-axis to avoid internal cavity overhangs; baseplates remain flat

https://claude.ai/code/session_01WShtPjpBQXrrZNdFU5uKkM