### PR TITLE
Add project persistence and export settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ src/
 │   ├── constants.ts       # Dimension profiles, default params, print bed presets
 │   └── snapping.ts        # Grid snapping logic
 ├── hooks/                 # Custom React hooks (keyboard shortcuts)
-├── store/                 # Zustand stores (project, UI, profile)
+├── store/                 # Zustand stores (project, UI, profile, project manager)
 │   └── __tests__/         # Unit tests for stores
 ├── types/                 # TypeScript interfaces
 └── lib/                   # Utility functions
@@ -57,11 +57,13 @@ e2e/                       # Playwright e2e tests
 - **Modifier system**: Modifiers are composable entities that attach to bins (or other modifiers) via `parentId`. The union type `Modifier = DividerGridModifier | LabelTabModifier | ScoopModifier | InsertModifier | LidModifier` is switched on `modifier.kind`. Modifiers are stored flat in the project store and rendered recursively.
 - **ModifierContext**: When rendering modifier geometry, a `ModifierContext` object provides the available inner dimensions (width, depth, wall height, floor Y). This context flows from bin params down through nested modifiers, allowing each modifier to adapt to its parent's geometry.
 - **Geometry generators** are pure functions: `generate*(params, profile) → BufferGeometry`. They use `roundedRectShape()`, `extrudeShape()`, and `mergeGeometries()` from `primitives.ts`. Modifier generators take the form: `generate*(params, context, profile) → BufferGeometry`.
-- **Zustand stores** are the single source of truth. Components read from stores via selectors. No prop drilling for shared state.
+- **Polygon quality system**: `primitives.ts` exposes a module-level `setCurveQuality(quality)` / `getCurveSegments()` API. The `curveQuality` setting in `uiStore` drives segment counts (low=4, medium=8, high=16) used by `extrudeShape()`, `createCylinder()`, and `scoop.ts`. Viewport components include `curveQuality` in useMemo deps to trigger geometry regeneration on quality changes.
+- **Project persistence**: `projectManagerStore` manages project metadata and auto-save. Cross-store dirty tracking uses `useProjectStore.subscribe()` with an `isLoadingProject` flag to prevent marking dirty during project load. `initializeProject()` loads project data after Zustand persist middleware rehydrates.
+- **Zustand stores** are the single source of truth. Components read from stores via selectors. No prop drilling for shared state. The `projectManagerStore` uses Zustand's `persist` middleware for localStorage persistence of project metadata, while project data (objects + modifiers) is stored separately at `react-finity-project-{id}` localStorage keys.
 - **Profile system**: All dimension constants come from `GridfinityProfile` objects (Official, Tight Fit, Loose Fit). Geometry generators receive the active profile, not raw constants.
 - **Properties panels**: One component per object kind (`BaseplateProperties`, `BinProperties`), following the same pattern of sliders/switches with label + value display. BinProperties includes a `ModifierSection` that renders modifier cards recursively.
 - **View mode system**: The app has two views — Edit (design with panels + viewport) and Print Layout (print bed preview + export). `activeView` in `uiStore` controls which view is rendered. The toolbar shows a toggle and conditionally renders view-specific controls.
-- **Export pipeline**: `mergeObjectGeometry.ts` merges an object with all its modifiers into a single `BufferGeometry`. `printOrientation.ts` computes the optimal FDM print rotation. `printLayout.ts` arranges objects on a virtual print bed. `stlExporter.ts` exports to binary STL with optional ZIP bundling.
+- **Export pipeline**: `mergeObjectGeometry.ts` merges an object with all its modifiers into a single `BufferGeometry`. `printOrientation.ts` computes the optimal FDM print rotation. `printLayout.ts` arranges objects on a virtual print bed. `stlExporter.ts` exports to binary STL with optional ZIP bundling and configurable scale factor.
 - **Shared geometry functions**: `generateModifierGeometry()` and `computeBinContext()` are defined in `src/engine/export/mergeObjectGeometry.ts` and imported by both `SceneObject.tsx` (for viewport rendering) and the export pipeline (for merging). Avoid duplicating these.
 - **Path alias**: `@/` maps to `src/` (configured in vite.config.ts and tsconfig)
 
@@ -163,5 +165,5 @@ See `ROADMAP.md` for the full project phases. Current status:
 - Phase 2: Bin Generation & Core Features — Complete
 - Phase 3: Interactivity & Manipulation — Complete
 - Phase 4: Modifier System & Advanced Geometry — Complete
-- Phase 5: Export & Print Layout — Complete (persistence deferred)
+- Phase 5: Export & Print Layout — Complete
 - Phase 6+: See ROADMAP.md

--- a/README.md
+++ b/README.md
@@ -14,11 +14,14 @@ A browser-based parametric 3D modeling application for the [Gridfinity](https://
   - Lid -- flat or stacking lid variant
 - **Print Layout view** -- dedicated view with virtual print bed, automatic FDM-optimal orientation, and row-based object arrangement
 - **STL export** -- binary STL export of individual objects, all objects as ZIP, or merged plate STL
+- **Export settings** -- configurable export scale (0.1x-10x) and polygon quality (Low/Medium/High)
+- **Project management** -- save, load, rename, and delete projects with auto-save (2s debounce) and Ctrl+S
+- **Local storage persistence** -- projects saved as JSON to browser localStorage, auto-loaded on startup
 - **Print bed presets** -- configurable bed sizes (220x220, 256x256, 350x350mm) with spacing control
 - **Real-time 3D viewport** -- orbit camera, transform gizmo, grid snapping, measurement overlay
 - **Camera presets** -- top, front, side, and isometric views
 - **Dimension profiles** -- Official, Tight Fit, and Loose Fit presets for all Gridfinity dimensions
-- **Keyboard shortcuts** -- Delete/Backspace to remove, Escape to deselect, Ctrl+P for print layout, Ctrl+Shift+E to export
+- **Keyboard shortcuts** -- Delete/Backspace to remove, Escape to deselect, Ctrl+P for print layout, Ctrl+Shift+E to export, Ctrl+S to save
 
 ## Tech Stack
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -95,11 +95,11 @@ Long-term, the app will transition to a native desktop experience via Tauri whil
 
 ---
 
-## Phase 5: Export & Print Layout ✅ (partial)
+## Phase 5: Export & Print Layout ✅
 
-**Status:** Export & print layout complete; persistence deferred
+**Status:** Complete
 
-**Goal:** Export to 3D printing formats and print-ready visualization.
+**Goal:** Export to 3D printing formats, print-ready visualization, project persistence, and export settings.
 
 **Delivered:**
 - **Print Layout view** — dedicated view mode with virtual print bed visualization, switchable via toolbar toggle (Edit/Print) or Ctrl+P
@@ -111,15 +111,15 @@ Long-term, the app will transition to a native desktop experience via Tauri whil
 - **ZIP export** — export all objects as individually named STL files bundled in a ZIP
 - **Single plate STL** — export all objects merged at their layout positions as one STL file
 - **Print Settings panel** — bed size selector, spacing slider, per-object dimensions display, fit indicators, and export buttons
-- **Keyboard shortcuts** — Ctrl+Shift+E to export selected object, Ctrl+P to toggle Print Layout view
-- Unit tests for geometry merging, print orientation, layout algorithm, and STL export (27 tests)
-- E2E tests for print layout view and export functionality (22 tests)
+- **Keyboard shortcuts** — Ctrl+Shift+E to export selected object, Ctrl+P to toggle Print Layout view, Ctrl+S to save project
+- **Local storage persistence** — projects saved as JSON (parameters + modifiers, not geometry) to localStorage with auto-save (2s debounce after last change)
+- **Project management** — toolbar Project dropdown with New/Save/Save As/Manage. Manage Projects dialog for loading, renaming, and deleting saved projects. Projects auto-load on startup
+- **Export settings** — configurable export scale (0.1x-10x) and polygon quality (Low/Medium/High) in Print Settings panel
+- Unit tests for geometry merging, print orientation, layout algorithm, STL export, project manager store, and export settings (45+ tests)
+- E2E tests for print layout view, export functionality, project management, and export settings (39 tests)
 
 **Deferred to later phase:**
 - 3MF export via three-3mf-exporter
-- Local storage persistence — save/load projects as JSON
-- Project management — new, save, load, rename, delete
-- Export settings — scale, polygon quality
 
 ---
 

--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -5,8 +5,8 @@ test.describe('App Loading & Initial State', () => {
     await page.goto('/')
   })
 
-  test('renders the app title in the toolbar', async ({ page }) => {
-    await expect(page.getByText('React-Finity')).toBeVisible()
+  test('renders the project name in the toolbar', async ({ page }) => {
+    await expect(page.getByTestId('project-name')).toBeVisible()
   })
 
   test('shows the Add Object button', async ({ page }) => {

--- a/e2e/export-settings.spec.ts
+++ b/e2e/export-settings.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Export Settings', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    // Switch to print layout view
+    await page.getByRole('button', { name: 'Print layout view' }).click()
+  })
+
+  test('shows Export Scale control in Print Settings', async ({ page }) => {
+    await expect(page.getByText('Export Scale')).toBeVisible()
+    await expect(page.getByText('100%')).toBeVisible()
+    await expect(page.getByLabel('Export scale')).toBeVisible()
+  })
+
+  test('shows Polygon Quality control in Print Settings', async ({ page }) => {
+    await expect(page.getByText('Polygon Quality')).toBeVisible()
+    await expect(page.getByLabel('Polygon quality')).toBeVisible()
+  })
+
+  test('Export Scale slider changes value', async ({ page }) => {
+    const slider = page.getByLabel('Export scale')
+    await slider.focus()
+
+    // Press right arrow to increase scale
+    await page.keyboard.press('ArrowRight')
+    // Value should change from 100%
+    await expect(page.getByText(/\d+%/)).toBeVisible()
+  })
+
+  test('Polygon Quality selector shows options', async ({ page }) => {
+    await page.getByLabel('Polygon quality').click()
+
+    await expect(page.getByRole('option', { name: 'Low' })).toBeVisible()
+    await expect(page.getByRole('option', { name: 'Medium' })).toBeVisible()
+    await expect(page.getByRole('option', { name: 'High' })).toBeVisible()
+  })
+
+  test('Polygon Quality can be changed', async ({ page }) => {
+    await page.getByLabel('Polygon quality').click()
+    await page.getByRole('option', { name: 'High' }).click()
+
+    // Verify selection stuck
+    await expect(page.getByLabel('Polygon quality')).toContainText('High')
+  })
+
+  test('Polygon Quality can be set to Low', async ({ page }) => {
+    await page.getByLabel('Polygon quality').click()
+    await page.getByRole('option', { name: 'Low' }).click()
+
+    await expect(page.getByLabel('Polygon quality')).toContainText('Low')
+  })
+})

--- a/e2e/project-management.spec.ts
+++ b/e2e/project-management.spec.ts
@@ -1,0 +1,153 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Project Management', () => {
+  test.beforeEach(async ({ page }) => {
+    // Clear localStorage before each test
+    await page.goto('/')
+    await page.evaluate(() => {
+      localStorage.clear()
+    })
+    await page.reload()
+  })
+
+  test('shows Project dropdown in toolbar', async ({ page }) => {
+    await expect(page.getByRole('button', { name: /Project/ })).toBeVisible()
+  })
+
+  test('Project dropdown shows menu items', async ({ page }) => {
+    await page.getByRole('button', { name: /Project/ }).click()
+
+    await expect(page.getByRole('menuitem', { name: /New Project/ })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: /^Save$/ })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: /Save As/ })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: /Manage Projects/ })).toBeVisible()
+  })
+
+  test('displays project name in toolbar', async ({ page }) => {
+    const projectName = page.getByTestId('project-name')
+    await expect(projectName).toBeVisible()
+    await expect(projectName).toHaveText('Untitled Project')
+  })
+
+  test('Save clears dirty indicator', async ({ page }) => {
+    // Add an object
+    await page.getByRole('button', { name: /Add Object/i }).click()
+    await page.getByRole('menuitem', { name: 'Bin' }).click()
+
+    // Manually save immediately
+    await page.getByRole('button', { name: /Project/ }).click()
+    await page.getByRole('menuitem', { name: /^Save$/ }).click()
+
+    // Dirty indicator should be gone
+    const projectName = page.getByTestId('project-name')
+    await expect(projectName).not.toContainText('*')
+  })
+
+  test('Save As creates a named project', async ({ page }) => {
+    // Add an object
+    await page.getByRole('button', { name: /Add Object/i }).click()
+    await page.getByRole('menuitem', { name: 'Bin' }).click()
+
+    // Save As
+    await page.getByRole('button', { name: /Project/ }).click()
+    await page.getByRole('menuitem', { name: /Save As/ }).click()
+
+    // Fill in the name
+    const nameInput = page.getByLabel('Project name')
+    await nameInput.clear()
+    await nameInput.fill('My Test Project')
+    await page.getByRole('button', { name: /^Save$/ }).click()
+
+    // Project name should update
+    const projectName = page.getByTestId('project-name')
+    await expect(projectName).toHaveText('My Test Project')
+  })
+
+  test('New Project clears objects', async ({ page }) => {
+    // Add an object
+    await page.getByRole('button', { name: /Add Object/i }).click()
+    await page.getByRole('menuitem', { name: 'Bin' }).click()
+
+    // Wait for the object to appear in the object list
+    await expect(page.getByText(/Bin \d+/).first()).toBeVisible()
+
+    // Click somewhere to ensure no dropdown is open
+    await page.mouse.click(400, 300)
+    await page.waitForTimeout(200)
+
+    // New Project
+    await page.getByRole('button', { name: /Project/ }).click()
+    await page.getByRole('menuitem', { name: /New Project/ }).click()
+
+    // Objects should be cleared
+    await expect(page.getByText('No objects yet')).toBeVisible()
+    const projectName = page.getByTestId('project-name')
+    await expect(projectName).toHaveText('Untitled Project')
+  })
+
+  test('Manage Projects dialog opens', async ({ page }) => {
+    await page.getByRole('button', { name: /Project/ }).click()
+    await page.getByRole('menuitem', { name: /Manage Projects/ }).click()
+
+    await expect(page.getByRole('heading', { name: 'Manage Projects' })).toBeVisible()
+    await expect(page.getByText('No saved projects yet')).toBeVisible()
+  })
+
+  test('Manage Projects lists saved projects', async ({ page }) => {
+    // Save a project
+    await page.getByRole('button', { name: /Add Object/i }).click()
+    await page.getByRole('menuitem', { name: 'Bin' }).click()
+    await page.getByRole('button', { name: /Project/ }).click()
+    await page.getByRole('menuitem', { name: /Save As/ }).click()
+    await page.getByLabel('Project name').fill('Saved Project')
+    await page.getByRole('button', { name: /^Save$/ }).click()
+
+    // Open manage dialog
+    await page.getByRole('button', { name: /Project/ }).click()
+    await page.getByRole('menuitem', { name: /Manage Projects/ }).click()
+
+    // Should show the saved project in the dialog using a more specific locator
+    const dialog = page.getByRole('dialog')
+    await expect(dialog.getByText('Saved Project', { exact: true })).toBeVisible()
+    await expect(dialog.getByText('Current')).toBeVisible()
+  })
+
+  test('Ctrl+S saves the project', async ({ page }) => {
+    // Press Ctrl+S on empty project
+    await page.keyboard.press('Control+s')
+
+    // Should have created a saved project
+    const projectName = page.getByTestId('project-name')
+    // After save, project name should not have dirty indicator
+    await expect(projectName).toHaveText('Untitled Project')
+
+    // Verify a project ID was assigned by checking that saving works
+    await page.getByRole('button', { name: /Project/ }).click()
+    await page.getByRole('menuitem', { name: /Manage Projects/ }).click()
+    const dialog = page.getByRole('dialog')
+    await expect(dialog.getByText('Untitled Project', { exact: true })).toBeVisible()
+  })
+
+  test('project persists across page reload', async ({ page }) => {
+    // Add an object and save
+    await page.getByRole('button', { name: /Add Object/i }).click()
+    await page.getByRole('menuitem', { name: 'Bin' }).click()
+    await page.getByRole('button', { name: /Project/ }).click()
+    await page.getByRole('menuitem', { name: /Save As/ }).click()
+    await page.getByLabel('Project name').fill('Persist Test')
+    await page.getByRole('button', { name: /^Save$/ }).click()
+
+    // Wait for save to complete
+    await page.waitForTimeout(500)
+
+    // Reload the page
+    await page.reload()
+
+    // Project name should be restored
+    const projectName = page.getByTestId('project-name')
+    await expect(projectName).toHaveText('Persist Test', { timeout: 10000 })
+
+    // Objects should be restored in the object list (with extra timeout for hydration)
+    await expect(page.getByText(/Bin \d+/).first()).toBeVisible({ timeout: 10000 })
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "react-finity",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-popover": "^1.1.15",
@@ -1441,6 +1442,60 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
       "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
       "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-popover": "^1.1.15",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,7 +1,15 @@
+import { useEffect } from 'react'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { Layout } from './Layout'
+import { useProjectManagerStore } from '@/store/projectManagerStore'
 
 export function App() {
+  const initializeProject = useProjectManagerStore((s) => s.initializeProject)
+
+  useEffect(() => {
+    initializeProject()
+  }, [initializeProject])
+
   return (
     <TooltipProvider>
       <div className="dark h-full">

--- a/src/components/panels/PrintSettingsPanel.tsx
+++ b/src/components/panels/PrintSettingsPanel.tsx
@@ -20,6 +20,7 @@ import { computePrintLayout, disposePrintLayout } from '@/engine/export/printLay
 import { mergeObjectWithModifiers } from '@/engine/export/mergeObjectGeometry'
 import { getPrintRotation, applyPrintOrientation } from '@/engine/export/printOrientation'
 import { exportObjectAsSTL, exportAllAsZip, exportAllAsSingleSTL } from '@/engine/export/stlExporter'
+import type { CurveQuality } from '@/types/gridfinity'
 
 export function PrintSettingsPanel() {
   const objects = useProjectStore((s) => s.objects)
@@ -29,6 +30,10 @@ export function PrintSettingsPanel() {
   const printBedSpacing = useUIStore((s) => s.printBedSpacing)
   const setPrintBedPreset = useUIStore((s) => s.setPrintBedPreset)
   const setPrintBedSpacing = useUIStore((s) => s.setPrintBedSpacing)
+  const exportScale = useUIStore((s) => s.exportScale)
+  const setExportScale = useUIStore((s) => s.setExportScale)
+  const curveQuality = useUIStore((s) => s.curveQuality)
+  const setCurveQuality = useUIStore((s) => s.setCurveQuality)
 
   const bed = PRINT_BED_PRESETS[printBedPreset] ?? PRINT_BED_PRESETS['256x256']
 
@@ -46,12 +51,12 @@ export function PrintSettingsPanel() {
 
   const handleExportAll = () => {
     if (layoutItems.length === 0) return
-    void exportAllAsZip(layoutItems)
+    void exportAllAsZip(layoutItems, exportScale)
   }
 
   const handleExportSingleSTL = () => {
     if (layoutItems.length === 0) return
-    exportAllAsSingleSTL(layoutItems)
+    exportAllAsSingleSTL(layoutItems, exportScale)
   }
 
   const handleExportOne = (objectId: string) => {
@@ -60,7 +65,7 @@ export function PrintSettingsPanel() {
     const merged = mergeObjectWithModifiers(obj, modifiers, activeProfile)
     const rotation = getPrintRotation(obj)
     const oriented = applyPrintOrientation(merged, rotation)
-    exportObjectAsSTL(oriented, obj.name)
+    exportObjectAsSTL(oriented, obj.name, exportScale)
     merged.dispose()
     oriented.dispose()
   }
@@ -105,6 +110,40 @@ export function PrintSettingsPanel() {
               onValueChange={([v]) => { setPrintBedSpacing(v) }}
               aria-label="Object spacing"
             />
+          </div>
+
+          <Separator />
+
+          {/* Export Settings */}
+          <div className="space-y-2">
+            <Label className="text-xs">Export Scale</Label>
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-muted-foreground">
+                {Math.round(exportScale * 100)}%
+              </span>
+            </div>
+            <Slider
+              min={0.1}
+              max={10}
+              step={0.1}
+              value={[exportScale]}
+              onValueChange={([v]) => { setExportScale(Math.round(v * 10) / 10) }}
+              aria-label="Export scale"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label className="text-xs">Polygon Quality</Label>
+            <Select value={curveQuality} onValueChange={(v) => { setCurveQuality(v as CurveQuality) }}>
+              <SelectTrigger className="h-8 text-xs" aria-label="Polygon quality">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="low">Low</SelectItem>
+                <SelectItem value="medium">Medium</SelectItem>
+                <SelectItem value="high">High</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
 
           <Separator />

--- a/src/components/toolbar/ProjectDialog.tsx
+++ b/src/components/toolbar/ProjectDialog.tsx
@@ -1,0 +1,205 @@
+import { useState } from 'react'
+import { FolderOpen, Pencil, Trash2, Check, X } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { Separator } from '@/components/ui/separator'
+import { useProjectManagerStore } from '@/store/projectManagerStore'
+
+interface ProjectDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function ProjectDialog({ open, onOpenChange }: ProjectDialogProps) {
+  const projects = useProjectManagerStore((s) => s.projects)
+  const currentProjectId = useProjectManagerStore((s) => s.currentProjectId)
+  const loadProject = useProjectManagerStore((s) => s.loadProject)
+  const renameProject = useProjectManagerStore((s) => s.renameProject)
+  const deleteProject = useProjectManagerStore((s) => s.deleteProject)
+
+  const [renamingId, setRenamingId] = useState<string | null>(null)
+  const [renameValue, setRenameValue] = useState('')
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null)
+
+  const sortedProjects = [...projects].sort(
+    (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+  )
+
+  const handleLoad = (id: string) => {
+    loadProject(id)
+    onOpenChange(false)
+  }
+
+  const handleStartRename = (id: string, currentName: string) => {
+    setRenamingId(id)
+    setRenameValue(currentName)
+    setConfirmDeleteId(null)
+  }
+
+  const handleConfirmRename = () => {
+    if (renamingId && renameValue.trim()) {
+      renameProject(renamingId, renameValue.trim())
+    }
+    setRenamingId(null)
+    setRenameValue('')
+  }
+
+  const handleCancelRename = () => {
+    setRenamingId(null)
+    setRenameValue('')
+  }
+
+  const handleDelete = (id: string) => {
+    deleteProject(id)
+    setConfirmDeleteId(null)
+  }
+
+  const formatDate = (iso: string): string => {
+    const date = new Date(iso)
+    return date.toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Manage Projects</DialogTitle>
+          <DialogDescription>Load, rename, or delete saved projects.</DialogDescription>
+        </DialogHeader>
+
+        {sortedProjects.length === 0 ? (
+          <div className="py-8 text-center text-sm text-muted-foreground">
+            No saved projects yet. Save your current project to see it here.
+          </div>
+        ) : (
+          <ScrollArea className="max-h-[300px]">
+            <div className="space-y-1">
+              {sortedProjects.map((project) => (
+                <div key={project.id}>
+                  <div className="flex items-center gap-2 rounded-md px-2 py-2 hover:bg-accent/50">
+                    {renamingId === project.id ? (
+                      <div className="flex flex-1 items-center gap-1">
+                        <Input
+                          value={renameValue}
+                          onChange={(e) => { setRenameValue(e.target.value) }}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter') handleConfirmRename()
+                            if (e.key === 'Escape') handleCancelRename()
+                          }}
+                          className="h-7 text-xs"
+                          autoFocus
+                          aria-label="Project name"
+                        />
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-6 w-6 shrink-0"
+                          onClick={handleConfirmRename}
+                          aria-label="Confirm rename"
+                        >
+                          <Check className="h-3 w-3" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-6 w-6 shrink-0"
+                          onClick={handleCancelRename}
+                          aria-label="Cancel rename"
+                        >
+                          <X className="h-3 w-3" />
+                        </Button>
+                      </div>
+                    ) : (
+                      <>
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center gap-1.5">
+                            <span className="truncate text-sm font-medium">
+                              {project.name}
+                            </span>
+                            {project.id === currentProjectId && (
+                              <span className="shrink-0 rounded bg-accent px-1 py-0.5 text-[10px] text-accent-foreground">
+                                Current
+                              </span>
+                            )}
+                          </div>
+                          <div className="text-[10px] text-muted-foreground">
+                            {formatDate(project.updatedAt)}
+                          </div>
+                        </div>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-6 w-6 shrink-0"
+                          onClick={() => { handleLoad(project.id) }}
+                          aria-label={`Load ${project.name}`}
+                        >
+                          <FolderOpen className="h-3 w-3" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-6 w-6 shrink-0"
+                          onClick={() => { handleStartRename(project.id, project.name) }}
+                          aria-label={`Rename ${project.name}`}
+                        >
+                          <Pencil className="h-3 w-3" />
+                        </Button>
+                        {confirmDeleteId === project.id ? (
+                          <div className="flex items-center gap-0.5">
+                            <Button
+                              variant="destructive"
+                              size="icon"
+                              className="h-6 w-6 shrink-0"
+                              onClick={() => { handleDelete(project.id) }}
+                              aria-label="Confirm delete"
+                            >
+                              <Check className="h-3 w-3" />
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-6 w-6 shrink-0"
+                              onClick={() => { setConfirmDeleteId(null) }}
+                              aria-label="Cancel delete"
+                            >
+                              <X className="h-3 w-3" />
+                            </Button>
+                          </div>
+                        ) : (
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-6 w-6 shrink-0"
+                            onClick={() => { setConfirmDeleteId(project.id) }}
+                            aria-label={`Delete ${project.name}`}
+                          >
+                            <Trash2 className="h-3 w-3" />
+                          </Button>
+                        )}
+                      </>
+                    )}
+                  </div>
+                  <Separator />
+                </div>
+              ))}
+            </div>
+          </ScrollArea>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/toolbar/Toolbar.tsx
+++ b/src/components/toolbar/Toolbar.tsx
@@ -1,4 +1,8 @@
-import { Plus, PanelLeft, PanelRight, Grid3x3, Download, Pencil, Printer } from 'lucide-react'
+import { useState } from 'react'
+import {
+  Plus, PanelLeft, PanelRight, Grid3x3, Download, Pencil, Printer,
+  FolderOpen, Save, FilePlus, FolderCog,
+} from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -10,9 +14,11 @@ import {
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { CameraPresets } from './CameraPresets'
 import { ViewportSettings } from './ViewportSettings'
+import { ProjectDialog } from './ProjectDialog'
 import { useProjectStore } from '@/store/projectStore'
 import { useProfileStore } from '@/store/profileStore'
 import { useUIStore } from '@/store/uiStore'
+import { useProjectManagerStore } from '@/store/projectManagerStore'
 import { cn } from '@/lib/utils'
 import { mergeObjectWithModifiers } from '@/engine/export/mergeObjectGeometry'
 import { getPrintRotation, applyPrintOrientation } from '@/engine/export/printOrientation'
@@ -30,7 +36,18 @@ export function Toolbar() {
   const toggleSnapToGrid = useUIStore((s) => s.toggleSnapToGrid)
   const activeView = useUIStore((s) => s.activeView)
   const setActiveView = useUIStore((s) => s.setActiveView)
+  const exportScale = useUIStore((s) => s.exportScale)
   const activeProfile = useProfileStore((s) => s.activeProfile)
+
+  const currentProjectName = useProjectManagerStore((s) => s.currentProjectName)
+  const isDirty = useProjectManagerStore((s) => s.isDirty)
+  const newProject = useProjectManagerStore((s) => s.newProject)
+  const saveProject = useProjectManagerStore((s) => s.saveProject)
+  const saveProjectAs = useProjectManagerStore((s) => s.saveProjectAs)
+
+  const [projectDialogOpen, setProjectDialogOpen] = useState(false)
+  const [saveAsPrompt, setSaveAsPrompt] = useState(false)
+  const [saveAsName, setSaveAsName] = useState('')
 
   const handleAddBaseplate = () => {
     const id = addObject('baseplate')
@@ -50,161 +67,242 @@ export function Toolbar() {
     const merged = mergeObjectWithModifiers(obj, modifiers, activeProfile)
     const rotation = getPrintRotation(obj)
     const oriented = applyPrintOrientation(merged, rotation)
-    exportObjectAsSTL(oriented, obj.name)
+    exportObjectAsSTL(oriented, obj.name, exportScale)
     merged.dispose()
     oriented.dispose()
+  }
+
+  const handleSaveAs = () => {
+    setSaveAsName(currentProjectName)
+    setSaveAsPrompt(true)
+  }
+
+  const handleConfirmSaveAs = () => {
+    if (saveAsName.trim()) {
+      saveProjectAs(saveAsName.trim())
+    }
+    setSaveAsPrompt(false)
+    setSaveAsName('')
   }
 
   const isEditView = activeView === 'edit'
 
   return (
-    <div className="flex h-10 items-center gap-2 border-b border-border bg-background px-3">
-      {/* Left panel toggle */}
-      <Button variant="ghost" size="icon" onClick={toggleLeftPanel} className="h-7 w-7">
-        <PanelLeft className="h-4 w-4" />
-      </Button>
+    <>
+      <div className="flex h-10 items-center gap-2 border-b border-border bg-background px-3">
+        {/* Left panel toggle */}
+        <Button variant="ghost" size="icon" onClick={toggleLeftPanel} className="h-7 w-7">
+          <PanelLeft className="h-4 w-4" />
+        </Button>
 
-      <div className="h-5 w-px bg-border" />
+        <div className="h-5 w-px bg-border" />
 
-      {/* View mode toggle */}
-      <TooltipProvider delayDuration={300}>
-        <div className="flex items-center gap-0.5 rounded-md border border-border p-0.5">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="sm"
-                className={cn(
-                  'h-6 gap-1 px-2 text-xs',
-                  isEditView && 'bg-accent text-accent-foreground',
-                )}
-                onClick={() => { setActiveView('edit') }}
-                aria-label="Edit view"
-                aria-pressed={isEditView}
-              >
-                <Pencil className="h-3 w-3" />
-                Edit
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Edit view</TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="sm"
-                className={cn(
-                  'h-6 gap-1 px-2 text-xs',
-                  !isEditView && 'bg-accent text-accent-foreground',
-                )}
-                onClick={() => { setActiveView('printLayout') }}
-                aria-label="Print layout view"
-                aria-pressed={!isEditView}
-              >
-                <Printer className="h-3 w-3" />
-                Print
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Print layout view</TooltipContent>
-          </Tooltip>
-        </div>
-      </TooltipProvider>
+        {/* Project dropdown */}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="sm" className="h-7 gap-1">
+              <FolderOpen className="h-4 w-4" />
+              Project
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem onClick={newProject}>
+              <FilePlus className="mr-2 h-4 w-4" />
+              New Project
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={saveProject}>
+              <Save className="mr-2 h-4 w-4" />
+              Save
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={handleSaveAs}>
+              <Save className="mr-2 h-4 w-4" />
+              Save As...
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={() => { setProjectDialogOpen(true) }}>
+              <FolderCog className="mr-2 h-4 w-4" />
+              Manage Projects...
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
 
-      <div className="h-5 w-px bg-border" />
+        <div className="h-5 w-px bg-border" />
 
-      {/* Edit view controls */}
-      {isEditView && (
-        <>
-          {/* Add object dropdown */}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="sm" className="h-7 gap-1">
-                <Plus className="h-4 w-4" />
-                Add Object
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent>
-              <DropdownMenuItem onClick={handleAddBaseplate}>Baseplate</DropdownMenuItem>
-              <DropdownMenuItem onClick={handleAddBin}>Bin</DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-
-          <div className="h-5 w-px bg-border" />
-
-          {/* Camera presets */}
-          <CameraPresets />
-
-          <div className="h-5 w-px bg-border" />
-
-          {/* Snap to grid toggle */}
-          <TooltipProvider delayDuration={300}>
+        {/* View mode toggle */}
+        <TooltipProvider delayDuration={300}>
+          <div className="flex items-center gap-0.5 rounded-md border border-border p-0.5">
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button
                   variant="ghost"
-                  size="icon"
-                  className={cn('h-7 w-7', snapToGrid && 'bg-accent text-accent-foreground')}
-                  onClick={toggleSnapToGrid}
-                  aria-label="Snap to grid"
-                  aria-pressed={snapToGrid}
+                  size="sm"
+                  className={cn(
+                    'h-6 gap-1 px-2 text-xs',
+                    isEditView && 'bg-accent text-accent-foreground',
+                  )}
+                  onClick={() => { setActiveView('edit') }}
+                  aria-label="Edit view"
+                  aria-pressed={isEditView}
                 >
-                  <Grid3x3 className="h-4 w-4" />
+                  <Pencil className="h-3 w-3" />
+                  Edit
                 </Button>
               </TooltipTrigger>
-              <TooltipContent>Snap to grid</TooltipContent>
+              <TooltipContent>Edit view</TooltipContent>
             </Tooltip>
-          </TooltipProvider>
-        </>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className={cn(
+                    'h-6 gap-1 px-2 text-xs',
+                    !isEditView && 'bg-accent text-accent-foreground',
+                  )}
+                  onClick={() => { setActiveView('printLayout') }}
+                  aria-label="Print layout view"
+                  aria-pressed={!isEditView}
+                >
+                  <Printer className="h-3 w-3" />
+                  Print
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Print layout view</TooltipContent>
+            </Tooltip>
+          </div>
+        </TooltipProvider>
+
+        <div className="h-5 w-px bg-border" />
+
+        {/* Edit view controls */}
+        {isEditView && (
+          <>
+            {/* Add object dropdown */}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="sm" className="h-7 gap-1">
+                  <Plus className="h-4 w-4" />
+                  Add Object
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent>
+                <DropdownMenuItem onClick={handleAddBaseplate}>Baseplate</DropdownMenuItem>
+                <DropdownMenuItem onClick={handleAddBin}>Bin</DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+
+            <div className="h-5 w-px bg-border" />
+
+            {/* Camera presets */}
+            <CameraPresets />
+
+            <div className="h-5 w-px bg-border" />
+
+            {/* Snap to grid toggle */}
+            <TooltipProvider delayDuration={300}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className={cn('h-7 w-7', snapToGrid && 'bg-accent text-accent-foreground')}
+                    onClick={toggleSnapToGrid}
+                    aria-label="Snap to grid"
+                    aria-pressed={snapToGrid}
+                  >
+                    <Grid3x3 className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Snap to grid</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </>
+        )}
+
+        {/* Spacer */}
+        <div className="flex-1" />
+
+        {/* Project name */}
+        <span className="text-xs font-medium text-muted-foreground" data-testid="project-name">
+          {currentProjectName}{isDirty ? ' *' : ''}
+        </span>
+
+        {/* Spacer */}
+        <div className="flex-1" />
+
+        {/* Export dropdown */}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="sm" className="h-7 gap-1">
+              <Download className="h-4 w-4" />
+              Export
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem
+              onClick={handleExportSelected}
+              disabled={!selectedObjectId || !isEditView}
+            >
+              Export Selected (STL)
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onClick={() => { setActiveView('printLayout') }}
+              disabled={!isEditView}
+            >
+              Open Print Layout
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        {/* Viewport settings (edit view only) */}
+        {isEditView && (
+          <>
+            <div className="h-5 w-px bg-border" />
+            <ViewportSettings />
+          </>
+        )}
+
+        <div className="h-5 w-px bg-border" />
+
+        {/* Right panel toggle */}
+        <Button variant="ghost" size="icon" onClick={toggleRightPanel} className="h-7 w-7">
+          <PanelRight className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {/* Project management dialog */}
+      <ProjectDialog open={projectDialogOpen} onOpenChange={setProjectDialogOpen} />
+
+      {/* Save As prompt - simple inline dialog */}
+      {saveAsPrompt && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80">
+          <div className="w-full max-w-sm rounded-lg border bg-background p-6 shadow-lg">
+            <h3 className="mb-4 text-sm font-semibold">Save Project As</h3>
+            <input
+              type="text"
+              value={saveAsName}
+              onChange={(e) => { setSaveAsName(e.target.value) }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handleConfirmSaveAs()
+                if (e.key === 'Escape') setSaveAsPrompt(false)
+              }}
+              className="mb-4 flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              autoFocus
+              placeholder="Project name"
+              aria-label="Project name"
+            />
+            <div className="flex justify-end gap-2">
+              <Button variant="ghost" size="sm" onClick={() => { setSaveAsPrompt(false) }}>
+                Cancel
+              </Button>
+              <Button size="sm" onClick={handleConfirmSaveAs} disabled={!saveAsName.trim()}>
+                Save
+              </Button>
+            </div>
+          </div>
+        </div>
       )}
-
-      {/* Spacer */}
-      <div className="flex-1" />
-
-      {/* App title */}
-      <span className="text-xs font-medium text-muted-foreground">React-Finity</span>
-
-      {/* Spacer */}
-      <div className="flex-1" />
-
-      {/* Export dropdown */}
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button variant="ghost" size="sm" className="h-7 gap-1">
-            <Download className="h-4 w-4" />
-            Export
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          <DropdownMenuItem
-            onClick={handleExportSelected}
-            disabled={!selectedObjectId || !isEditView}
-          >
-            Export Selected (STL)
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem
-            onClick={() => { setActiveView('printLayout') }}
-            disabled={!isEditView}
-          >
-            Open Print Layout
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-
-      {/* Viewport settings (edit view only) */}
-      {isEditView && (
-        <>
-          <div className="h-5 w-px bg-border" />
-          <ViewportSettings />
-        </>
-      )}
-
-      <div className="h-5 w-px bg-border" />
-
-      {/* Right panel toggle */}
-      <Button variant="ghost" size="icon" onClick={toggleRightPanel} className="h-7 w-7">
-        <PanelRight className="h-4 w-4" />
-      </Button>
-    </div>
+    </>
   )
 }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,110 @@
+import * as React from 'react'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { X } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className,
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+function DialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)}
+      {...props}
+    />
+  )
+}
+DialogHeader.displayName = 'DialogHeader'
+
+function DialogFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
+      {...props}
+    />
+  )
+}
+DialogFooter.displayName = 'DialogFooter'
+
+const DialogTitle = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-muted-foreground', className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+// eslint-disable-next-line react-refresh/only-export-components
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  },
+)
+Input.displayName = 'Input'
+
+// eslint-disable-next-line react-refresh/only-export-components
+export { Input }

--- a/src/components/viewport/SceneObject.tsx
+++ b/src/components/viewport/SceneObject.tsx
@@ -51,9 +51,11 @@ interface ModifierMeshProps {
 }
 
 function ModifierMesh({ modifier, context, profile }: ModifierMeshProps) {
+  const curveQuality = useUIStore((s) => s.curveQuality)
   const geometry = useMemo(() => {
     return generateModifierGeometry(modifier, context, profile)
-  }, [modifier, context, profile])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [modifier, context, profile, curveQuality])
 
   // Compute child context for nested modifiers
   const childContext = useMemo((): ModifierContext | null => {
@@ -113,6 +115,7 @@ export function SceneObject({ object }: SceneObjectProps) {
   const selectedObjectId = useUIStore((s) => s.selectedObjectId)
   const selectObject = useUIStore((s) => s.selectObject)
 
+  const curveQuality = useUIStore((s) => s.curveQuality)
   const isSelected = selectedObjectId === object.id
 
   const geometry = useMemo(() => {
@@ -122,7 +125,8 @@ export function SceneObject({ object }: SceneObjectProps) {
       case 'bin':
         return generateBin(object.params, activeProfile)
     }
-  }, [object.kind, object.params, activeProfile])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [object.kind, object.params, activeProfile, curveQuality])
 
   const binContext = useMemo(() => {
     if (object.kind === 'bin') {

--- a/src/engine/export/stlExporter.ts
+++ b/src/engine/export/stlExporter.ts
@@ -7,13 +7,27 @@ function sanitizeFilename(name: string): string {
   return name.replace(/[^a-zA-Z0-9_\-. ]/g, '_').trim() || 'object'
 }
 
-function geometryToSTLBinary(geometry: THREE.BufferGeometry): ArrayBuffer {
+function geometryToSTLBinary(geometry: THREE.BufferGeometry, scale = 1): ArrayBuffer {
   const exporter = new STLExporter()
-  const mesh = new THREE.Mesh(geometry, new THREE.MeshBasicMaterial())
+  let geo = geometry
+  let needsDispose = false
+
+  if (scale !== 1) {
+    geo = geometry.clone()
+    geo.scale(scale, scale, scale)
+    needsDispose = true
+  }
+
+  const mesh = new THREE.Mesh(geo, new THREE.MeshBasicMaterial())
   const result = exporter.parse(mesh, { binary: true }) as DataView
   // Copy to a plain ArrayBuffer to satisfy BlobPart/JSZip type constraints
   const arrayBuffer = new ArrayBuffer(result.byteLength)
   new Uint8Array(arrayBuffer).set(new Uint8Array(result.buffer as ArrayBuffer))
+
+  if (needsDispose) {
+    geo.dispose()
+  }
+
   return arrayBuffer
 }
 
@@ -31,8 +45,8 @@ function triggerDownload(blob: Blob, filename: string): void {
 /**
  * Export a single geometry as a binary STL file download.
  */
-export function exportObjectAsSTL(geometry: THREE.BufferGeometry, name: string): void {
-  const buffer = geometryToSTLBinary(geometry)
+export function exportObjectAsSTL(geometry: THREE.BufferGeometry, name: string, scale = 1): void {
+  const buffer = geometryToSTLBinary(geometry, scale)
   const blob = new Blob([buffer], { type: 'application/octet-stream' })
   triggerDownload(blob, `${sanitizeFilename(name)}.stl`)
 }
@@ -40,11 +54,11 @@ export function exportObjectAsSTL(geometry: THREE.BufferGeometry, name: string):
 /**
  * Export all print layout items as individual STL files bundled in a ZIP.
  */
-export async function exportAllAsZip(items: PrintLayoutItem[]): Promise<void> {
+export async function exportAllAsZip(items: PrintLayoutItem[], scale = 1): Promise<void> {
   const zip = new JSZip()
 
   for (const item of items) {
-    const data = geometryToSTLBinary(item.geometry)
+    const data = geometryToSTLBinary(item.geometry, scale)
     const filename = `${sanitizeFilename(item.object.name)}.stl`
     zip.file(filename, data)
   }
@@ -57,7 +71,7 @@ export async function exportAllAsZip(items: PrintLayoutItem[]): Promise<void> {
  * Export all print layout items as a single merged STL with objects at
  * their layout positions.
  */
-export function exportAllAsSingleSTL(items: PrintLayoutItem[]): void {
+export function exportAllAsSingleSTL(items: PrintLayoutItem[], scale = 1): void {
   if (items.length === 0) return
 
   const geometries: THREE.BufferGeometry[] = []
@@ -124,7 +138,7 @@ export function exportAllAsSingleSTL(items: PrintLayoutItem[]): void {
   merged.setIndex(new THREE.BufferAttribute(indices, 1))
   merged.computeVertexNormals()
 
-  const buffer = geometryToSTLBinary(merged)
+  const buffer = geometryToSTLBinary(merged, scale)
   const blob = new Blob([buffer], { type: 'application/octet-stream' })
   triggerDownload(blob, 'react-finity-plate.stl')
 

--- a/src/engine/geometry/modifiers/scoop.ts
+++ b/src/engine/geometry/modifiers/scoop.ts
@@ -2,7 +2,7 @@ import * as THREE from 'three'
 
 import type { ScoopModifierParams, ModifierContext, GridfinityProfile } from '@/types/gridfinity'
 
-import { mergeGeometries } from '../primitives'
+import { mergeGeometries, getCurveSegments } from '../primitives'
 
 export function generateScoop(
   params: ScoopModifierParams,
@@ -19,7 +19,7 @@ export function generateScoop(
   // Create half-cylinder geometry
   const isXWall = wall === 'front' || wall === 'back'
   const span = isXWall ? innerWidth : innerDepth
-  const segments = 16
+  const segments = getCurveSegments() * 2
 
   // Build a half-cylinder as a custom geometry
   const geo = new THREE.CylinderGeometry(

--- a/src/engine/geometry/primitives.ts
+++ b/src/engine/geometry/primitives.ts
@@ -1,4 +1,21 @@
 import * as THREE from 'three'
+import type { CurveQuality } from '@/types/gridfinity'
+
+const QUALITY_SEGMENTS: Record<CurveQuality, number> = {
+  low: 4,
+  medium: 8,
+  high: 16,
+}
+
+let activeCurveSegments = QUALITY_SEGMENTS.medium
+
+export function setCurveQuality(quality: CurveQuality): void {
+  activeCurveSegments = QUALITY_SEGMENTS[quality]
+}
+
+export function getCurveSegments(): number {
+  return activeCurveSegments
+}
 
 /**
  * Create a 2D rounded rectangle shape.
@@ -36,6 +53,7 @@ export function extrudeShape(
     depth: height,
     bevelEnabled,
     steps: 1,
+    curveSegments: activeCurveSegments,
   })
   // ExtrudeGeometry extrudes along Z, rotate to extrude along Y
   geometry.rotateX(-Math.PI / 2)
@@ -50,7 +68,7 @@ export function extrudeShape(
 export function createCylinder(
   radius: number,
   height: number,
-  segments = 24,
+  segments = activeCurveSegments * 3,
 ): THREE.BufferGeometry {
   return new THREE.CylinderGeometry(radius, radius, height, segments)
 }

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import { useProjectStore } from '@/store/projectStore'
 import { useProfileStore } from '@/store/profileStore'
 import { useUIStore } from '@/store/uiStore'
+import { useProjectManagerStore } from '@/store/projectManagerStore'
 import { mergeObjectWithModifiers } from '@/engine/export/mergeObjectGeometry'
 import { getPrintRotation, applyPrintOrientation } from '@/engine/export/printOrientation'
 import { exportObjectAsSTL } from '@/engine/export/stlExporter'
@@ -35,6 +36,12 @@ export function useKeyboardShortcuts() {
         selectObject(null)
       }
 
+      // Ctrl+S: Save project
+      if ((e.ctrlKey || e.metaKey) && e.key === 's' && !e.shiftKey) {
+        e.preventDefault()
+        useProjectManagerStore.getState().saveProject()
+      }
+
       // Ctrl+Shift+E: Export selected object as STL
       if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'E') {
         e.preventDefault()
@@ -44,10 +51,11 @@ export function useKeyboardShortcuts() {
           const profile = useProfileStore.getState().activeProfile
           const obj = objects.find((o) => o.id === selectedObjectId)
           if (obj) {
+            const scale = useUIStore.getState().exportScale
             const merged = mergeObjectWithModifiers(obj, modifiers, profile)
             const rotation = getPrintRotation(obj)
             const oriented = applyPrintOrientation(merged, rotation)
-            exportObjectAsSTL(oriented, obj.name)
+            exportObjectAsSTL(oriented, obj.name, scale)
             merged.dispose()
             oriented.dispose()
           }

--- a/src/store/__tests__/projectManagerStore.test.ts
+++ b/src/store/__tests__/projectManagerStore.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { useProjectManagerStore } from '../projectManagerStore'
+import { useProjectStore } from '../projectStore'
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value },
+    removeItem: (key: string) => { delete store[key] },
+    clear: () => { store = {} },
+    get length() { return Object.keys(store).length },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+  }
+})()
+
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock })
+
+describe('projectManagerStore', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    localStorageMock.clear()
+    useProjectStore.setState({ objects: [], modifiers: [] })
+    useProjectManagerStore.setState({
+      currentProjectId: null,
+      currentProjectName: 'Untitled Project',
+      isDirty: false,
+      projects: [],
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('starts with empty state', () => {
+    const state = useProjectManagerStore.getState()
+    expect(state.currentProjectId).toBeNull()
+    expect(state.currentProjectName).toBe('Untitled Project')
+    expect(state.isDirty).toBe(false)
+    expect(state.projects).toEqual([])
+  })
+
+  it('saves a new project', () => {
+    // Add an object to projectStore
+    useProjectStore.getState().addObject('bin')
+
+    useProjectManagerStore.getState().saveProject()
+
+    const state = useProjectManagerStore.getState()
+    expect(state.currentProjectId).not.toBeNull()
+    expect(state.isDirty).toBe(false)
+    expect(state.projects).toHaveLength(1)
+    expect(state.projects[0].name).toBe('Untitled Project')
+
+    // Verify localStorage has the data
+    const raw = localStorageMock.getItem(`react-finity-project-${state.currentProjectId}`)
+    expect(raw).not.toBeNull()
+    const data = JSON.parse(raw!)  // eslint-disable-line @typescript-eslint/no-non-null-assertion
+    expect(data.objects).toHaveLength(1)
+  })
+
+  it('saves as a new project with given name', () => {
+    useProjectStore.getState().addObject('baseplate')
+
+    useProjectManagerStore.getState().saveProjectAs('My Cool Project')
+
+    const state = useProjectManagerStore.getState()
+    expect(state.currentProjectName).toBe('My Cool Project')
+    expect(state.projects).toHaveLength(1)
+    expect(state.projects[0].name).toBe('My Cool Project')
+  })
+
+  it('loads a saved project', () => {
+    // Save a project first
+    useProjectStore.getState().addObject('bin')
+    useProjectManagerStore.getState().saveProjectAs('Test Project')
+
+    const savedId = useProjectManagerStore.getState().currentProjectId!  // eslint-disable-line @typescript-eslint/no-non-null-assertion
+
+    // Clear project store to simulate a new project
+    useProjectStore.setState({ objects: [], modifiers: [] })
+    useProjectManagerStore.setState({
+      currentProjectId: null,
+      currentProjectName: 'Other Project',
+    })
+
+    // Load the saved project
+    useProjectManagerStore.getState().loadProject(savedId)
+
+    const state = useProjectManagerStore.getState()
+    expect(state.currentProjectId).toBe(savedId)
+    expect(state.currentProjectName).toBe('Test Project')
+    expect(state.isDirty).toBe(false)
+
+    // Verify projectStore was populated
+    expect(useProjectStore.getState().objects).toHaveLength(1)
+  })
+
+  it('creates a new project', () => {
+    // Save a project and add objects
+    useProjectStore.getState().addObject('bin')
+    useProjectManagerStore.getState().saveProject()
+
+    // Create new project
+    useProjectManagerStore.getState().newProject()
+
+    const state = useProjectManagerStore.getState()
+    expect(state.currentProjectId).toBeNull()
+    expect(state.currentProjectName).toBe('Untitled Project')
+    expect(state.isDirty).toBe(false)
+    expect(useProjectStore.getState().objects).toEqual([])
+    expect(useProjectStore.getState().modifiers).toEqual([])
+  })
+
+  it('renames a project', () => {
+    useProjectManagerStore.getState().saveProjectAs('Original Name')
+    const id = useProjectManagerStore.getState().currentProjectId!  // eslint-disable-line @typescript-eslint/no-non-null-assertion
+
+    useProjectManagerStore.getState().renameProject(id, 'New Name')
+
+    const state = useProjectManagerStore.getState()
+    expect(state.currentProjectName).toBe('New Name')
+    expect(state.projects[0].name).toBe('New Name')
+  })
+
+  it('deletes a non-current project', () => {
+    // Create two projects
+    useProjectManagerStore.getState().saveProjectAs('Project 1')
+    const id1 = useProjectManagerStore.getState().currentProjectId!  // eslint-disable-line @typescript-eslint/no-non-null-assertion
+
+    useProjectManagerStore.getState().saveProjectAs('Project 2')
+
+    expect(useProjectManagerStore.getState().projects).toHaveLength(2)
+
+    // Delete the first project (not currently active)
+    useProjectManagerStore.getState().deleteProject(id1)
+
+    const state = useProjectManagerStore.getState()
+    expect(state.projects).toHaveLength(1)
+    expect(state.projects[0].name).toBe('Project 2')
+    expect(state.currentProjectName).toBe('Project 2')
+  })
+
+  it('deletes the current project and creates a new one', () => {
+    useProjectStore.getState().addObject('bin')
+    useProjectManagerStore.getState().saveProjectAs('To Delete')
+    const id = useProjectManagerStore.getState().currentProjectId!  // eslint-disable-line @typescript-eslint/no-non-null-assertion
+
+    useProjectManagerStore.getState().deleteProject(id)
+
+    const state = useProjectManagerStore.getState()
+    expect(state.currentProjectId).toBeNull()
+    expect(state.currentProjectName).toBe('Untitled Project')
+    expect(state.projects).toHaveLength(0)
+    expect(useProjectStore.getState().objects).toEqual([])
+  })
+
+  it('marks dirty and auto-saves after debounce', () => {
+    useProjectStore.getState().addObject('bin')
+    useProjectManagerStore.getState().saveProject()
+
+    const projectId = useProjectManagerStore.getState().currentProjectId!  // eslint-disable-line @typescript-eslint/no-non-null-assertion
+
+    // Manually mark dirty
+    useProjectManagerStore.getState().markDirty()
+    expect(useProjectManagerStore.getState().isDirty).toBe(true)
+
+    // Before timer fires, should still be dirty
+    vi.advanceTimersByTime(1000)
+    expect(useProjectManagerStore.getState().isDirty).toBe(true)
+
+    // After 2s debounce, auto-save should fire
+    vi.advanceTimersByTime(1500)
+    expect(useProjectManagerStore.getState().isDirty).toBe(false)
+
+    // Data should be persisted
+    const raw = localStorageMock.getItem(`react-finity-project-${projectId}`)
+    expect(raw).not.toBeNull()
+  })
+
+  it('debounce resets on subsequent markDirty calls', () => {
+    useProjectStore.getState().addObject('bin')
+    useProjectManagerStore.getState().saveProject()
+
+    useProjectManagerStore.getState().markDirty()
+
+    // Wait 1.5s then mark dirty again
+    vi.advanceTimersByTime(1500)
+    expect(useProjectManagerStore.getState().isDirty).toBe(true)
+
+    useProjectManagerStore.getState().markDirty()
+
+    // 1.5s later, should still be dirty (debounce reset)
+    vi.advanceTimersByTime(1500)
+    expect(useProjectManagerStore.getState().isDirty).toBe(true)
+
+    // 0.5s more (total 2s from last markDirty), should be saved
+    vi.advanceTimersByTime(500)
+    expect(useProjectManagerStore.getState().isDirty).toBe(false)
+  })
+
+  it('saves project updates updatedAt timestamp', () => {
+    useProjectManagerStore.getState().saveProjectAs('Timestamp Test')
+    const firstSave = useProjectManagerStore.getState().projects[0].updatedAt
+
+    // Wait a bit and save again
+    vi.advanceTimersByTime(5000)
+    useProjectManagerStore.getState().saveProject()
+    const secondSave = useProjectManagerStore.getState().projects[0].updatedAt
+
+    expect(new Date(secondSave).getTime()).toBeGreaterThanOrEqual(new Date(firstSave).getTime())
+  })
+
+  it('handles loading nonexistent project gracefully', () => {
+    useProjectManagerStore.getState().loadProject('nonexistent-id')
+
+    // State should be unchanged
+    expect(useProjectManagerStore.getState().currentProjectId).toBeNull()
+    expect(useProjectStore.getState().objects).toEqual([])
+  })
+})

--- a/src/store/__tests__/projectStore.test.ts
+++ b/src/store/__tests__/projectStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { useProjectStore } from '../projectStore'
+import { useProjectStore, resetObjectCounter } from '../projectStore'
 
 describe('projectStore', () => {
   beforeEach(() => {
@@ -279,5 +279,98 @@ describe('modifier CRUD', () => {
   it('getModifierContext returns null for unknown parent', () => {
     const context = useProjectStore.getState().getModifierContext('nonexistent-id')
     expect(context).toBeNull()
+  })
+
+  it('loads project data with objects and modifiers', () => {
+    const data = {
+      objects: [
+        {
+          kind: 'bin' as const,
+          id: 'test-bin-1',
+          name: 'Bin 5',
+          position: [0, 0, 0] as [number, number, number],
+          params: {
+            gridWidth: 2,
+            gridDepth: 2,
+            heightUnits: 4,
+            stackingLip: true,
+            wallThickness: 1.2,
+            innerFillet: 0,
+          },
+        },
+      ],
+      modifiers: [
+        {
+          kind: 'dividerGrid' as const,
+          id: 'test-div-1',
+          parentId: 'test-bin-1',
+          params: { dividersX: 1, dividersY: 1, wallThickness: 1.2 },
+        },
+      ],
+    }
+
+    useProjectStore.getState().loadProjectData(data)
+    const state = useProjectStore.getState()
+    expect(state.objects).toHaveLength(1)
+    expect(state.objects[0].id).toBe('test-bin-1')
+    expect(state.modifiers).toHaveLength(1)
+    expect(state.modifiers[0].id).toBe('test-div-1')
+  })
+
+  it('resets object counter after loading project data', () => {
+    const data = {
+      objects: [
+        {
+          kind: 'bin' as const,
+          id: 'b1',
+          name: 'Bin 7',
+          position: [0, 0, 0] as [number, number, number],
+          params: {
+            gridWidth: 1,
+            gridDepth: 1,
+            heightUnits: 3,
+            stackingLip: true,
+            wallThickness: 1.2,
+            innerFillet: 0,
+          },
+        },
+        {
+          kind: 'baseplate' as const,
+          id: 'bp1',
+          name: 'Baseplate 3',
+          position: [0, 0, 0] as [number, number, number],
+          params: {
+            gridWidth: 3,
+            gridDepth: 3,
+            magnetHoles: true,
+            screwHoles: false,
+          },
+        },
+      ],
+      modifiers: [],
+    }
+
+    useProjectStore.getState().loadProjectData(data)
+
+    // Next object should get counter > 7 (the max in loaded data)
+    const id = useProjectStore.getState().addObject('bin')
+    const newObj = useProjectStore.getState().objects.find((o) => o.id === id)
+    expect(newObj).toBeDefined()
+    const nameNum = parseInt(newObj!.name.match(/\d+$/)?.[0] ?? '0', 10) // eslint-disable-line @typescript-eslint/no-non-null-assertion
+    expect(nameNum).toBe(8)
+  })
+
+  it('resetObjectCounter finds max from mixed names', () => {
+    resetObjectCounter([
+      { kind: 'bin', id: '1', name: 'Bin 10', position: [0, 0, 0], params: { gridWidth: 1, gridDepth: 1, heightUnits: 3, stackingLip: true, wallThickness: 1.2, innerFillet: 0 } },
+      { kind: 'baseplate', id: '2', name: 'Custom Name', position: [0, 0, 0], params: { gridWidth: 3, gridDepth: 3, magnetHoles: true, screwHoles: false } },
+      { kind: 'bin', id: '3', name: 'Bin 3', position: [0, 0, 0], params: { gridWidth: 1, gridDepth: 1, heightUnits: 3, stackingLip: true, wallThickness: 1.2, innerFillet: 0 } },
+    ])
+    // After reset to 10, next addObject should produce counter 11
+    const id = useProjectStore.getState().addObject('bin')
+    const obj = useProjectStore.getState().objects.find((o) => o.id === id)
+    expect(obj!.name).toMatch(/\d+$/) // eslint-disable-line @typescript-eslint/no-non-null-assertion
+    const num = parseInt(obj!.name.match(/\d+$/)?.[0] ?? '0', 10) // eslint-disable-line @typescript-eslint/no-non-null-assertion
+    expect(num).toBe(11)
   })
 })

--- a/src/store/__tests__/uiStore.test.ts
+++ b/src/store/__tests__/uiStore.test.ts
@@ -15,6 +15,8 @@ describe('uiStore', () => {
       activeView: 'edit',
       printBedPreset: '256x256',
       printBedSpacing: 10,
+      exportScale: 1.0,
+      curveQuality: 'medium',
     })
   })
 
@@ -132,5 +134,26 @@ describe('uiStore', () => {
     expect(useUIStore.getState().printBedSpacing).toBe(15)
     useUIStore.getState().setPrintBedSpacing(5)
     expect(useUIStore.getState().printBedSpacing).toBe(5)
+  })
+
+  it('has correct default export settings', () => {
+    expect(useUIStore.getState().exportScale).toBe(1.0)
+    expect(useUIStore.getState().curveQuality).toBe('medium')
+  })
+
+  it('sets export scale', () => {
+    useUIStore.getState().setExportScale(2.0)
+    expect(useUIStore.getState().exportScale).toBe(2.0)
+    useUIStore.getState().setExportScale(0.5)
+    expect(useUIStore.getState().exportScale).toBe(0.5)
+  })
+
+  it('sets curve quality', () => {
+    useUIStore.getState().setCurveQuality('low')
+    expect(useUIStore.getState().curveQuality).toBe('low')
+    useUIStore.getState().setCurveQuality('high')
+    expect(useUIStore.getState().curveQuality).toBe('high')
+    useUIStore.getState().setCurveQuality('medium')
+    expect(useUIStore.getState().curveQuality).toBe('medium')
   })
 })

--- a/src/store/projectManagerStore.ts
+++ b/src/store/projectManagerStore.ts
@@ -1,0 +1,248 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+import { v4 as uuidv4 } from 'uuid'
+import type { ProjectMeta, ProjectData } from '@/types/gridfinity'
+import { useProjectStore, resetObjectCounter } from './projectStore'
+
+const PROJECT_DATA_KEY_PREFIX = 'react-finity-project-'
+const AUTO_SAVE_DELAY = 2000
+
+function projectDataKey(id: string): string {
+  return `${PROJECT_DATA_KEY_PREFIX}${id}`
+}
+
+function readProjectData(id: string): ProjectData | null {
+  try {
+    const raw = localStorage.getItem(projectDataKey(id))
+    if (!raw) return null
+    const data = JSON.parse(raw) as ProjectData
+    if (!Array.isArray(data.objects) || !Array.isArray(data.modifiers)) return null
+    return data
+  } catch {
+    return null
+  }
+}
+
+function writeProjectData(id: string, data: ProjectData): void {
+  localStorage.setItem(projectDataKey(id), JSON.stringify(data))
+}
+
+function deleteProjectData(id: string): void {
+  localStorage.removeItem(projectDataKey(id))
+}
+
+interface ProjectManagerStore {
+  currentProjectId: string | null
+  currentProjectName: string
+  isDirty: boolean
+  projects: ProjectMeta[]
+  newProject: () => void
+  saveProject: () => void
+  saveProjectAs: (name: string) => void
+  loadProject: (id: string) => void
+  renameProject: (id: string, name: string) => void
+  deleteProject: (id: string) => void
+  markDirty: () => void
+  initializeProject: () => void
+}
+
+let autoSaveTimer: ReturnType<typeof setTimeout> | null = null
+
+export const useProjectManagerStore = create<ProjectManagerStore>()(
+  persist(
+    (set, get) => ({
+      currentProjectId: null,
+      currentProjectName: 'Untitled Project',
+      isDirty: false,
+      projects: [],
+
+      newProject: () => {
+        if (autoSaveTimer) {
+          clearTimeout(autoSaveTimer)
+          autoSaveTimer = null
+        }
+        useProjectStore.getState().clearObjects()
+        resetObjectCounter([])
+        set({
+          currentProjectId: null,
+          currentProjectName: 'Untitled Project',
+          isDirty: false,
+        })
+      },
+
+      saveProject: () => {
+        if (autoSaveTimer) {
+          clearTimeout(autoSaveTimer)
+          autoSaveTimer = null
+        }
+
+        const state = get()
+        const { objects, modifiers } = useProjectStore.getState()
+        const now = new Date().toISOString()
+
+        let projectId = state.currentProjectId
+        if (!projectId) {
+          projectId = uuidv4()
+          const meta: ProjectMeta = {
+            id: projectId,
+            name: state.currentProjectName,
+            createdAt: now,
+            updatedAt: now,
+          }
+          set((s) => ({
+            currentProjectId: projectId,
+            isDirty: false,
+            projects: [...s.projects, meta],
+          }))
+        } else {
+          set((s) => ({
+            isDirty: false,
+            projects: s.projects.map((p) =>
+              p.id === projectId ? { ...p, updatedAt: now } : p,
+            ),
+          }))
+        }
+
+        writeProjectData(projectId, { objects, modifiers })
+      },
+
+      saveProjectAs: (name: string) => {
+        if (autoSaveTimer) {
+          clearTimeout(autoSaveTimer)
+          autoSaveTimer = null
+        }
+
+        const { objects, modifiers } = useProjectStore.getState()
+        const now = new Date().toISOString()
+        const projectId = uuidv4()
+
+        const meta: ProjectMeta = {
+          id: projectId,
+          name,
+          createdAt: now,
+          updatedAt: now,
+        }
+
+        writeProjectData(projectId, { objects, modifiers })
+
+        set((s) => ({
+          currentProjectId: projectId,
+          currentProjectName: name,
+          isDirty: false,
+          projects: [...s.projects, meta],
+        }))
+      },
+
+      loadProject: (id: string) => {
+        if (autoSaveTimer) {
+          clearTimeout(autoSaveTimer)
+          autoSaveTimer = null
+        }
+
+        const data = readProjectData(id)
+        if (!data) return
+
+        const meta = get().projects.find((p) => p.id === id)
+        if (!meta) return
+
+        useProjectStore.getState().loadProjectData(data)
+
+        set({
+          currentProjectId: id,
+          currentProjectName: meta.name,
+          isDirty: false,
+        })
+      },
+
+      renameProject: (id: string, name: string) => {
+        set((s) => ({
+          projects: s.projects.map((p) =>
+            p.id === id ? { ...p, name } : p,
+          ),
+          currentProjectName: s.currentProjectId === id ? name : s.currentProjectName,
+        }))
+      },
+
+      deleteProject: (id: string) => {
+        deleteProjectData(id)
+
+        const state = get()
+        const isCurrentProject = state.currentProjectId === id
+
+        set((s) => ({
+          projects: s.projects.filter((p) => p.id !== id),
+        }))
+
+        if (isCurrentProject) {
+          get().newProject()
+        }
+      },
+
+      markDirty: () => {
+        set({ isDirty: true })
+
+        if (autoSaveTimer) {
+          clearTimeout(autoSaveTimer)
+        }
+
+        autoSaveTimer = setTimeout(() => {
+          autoSaveTimer = null
+          get().saveProject()
+        }, AUTO_SAVE_DELAY)
+      },
+
+      initializeProject: () => {
+        const state = get()
+        if (state.currentProjectId) {
+          const data = readProjectData(state.currentProjectId)
+          if (data) {
+            useProjectStore.getState().loadProjectData(data)
+          }
+        }
+      },
+    }),
+    {
+      name: 'react-finity-project-manager',
+      partialize: (state) => ({
+        currentProjectId: state.currentProjectId,
+        currentProjectName: state.currentProjectName,
+        projects: state.projects,
+      }),
+    },
+  ),
+)
+
+// Flag to prevent auto-save triggering during project load operations.
+let isLoadingProject = false
+
+// Subscribe to projectStore changes and trigger auto-save.
+const originalLoadProjectData = useProjectStore.getState().loadProjectData
+useProjectStore.setState({
+  loadProjectData: (data) => {
+    isLoadingProject = true
+    originalLoadProjectData(data)
+    isLoadingProject = false
+  },
+})
+
+useProjectStore.subscribe((state, prevState) => {
+  if (isLoadingProject) return
+  if (state.objects !== prevState.objects || state.modifiers !== prevState.modifiers) {
+    useProjectManagerStore.getState().markDirty()
+  }
+})
+
+// Auto-load project data after persist middleware rehydrates.
+if (typeof window !== 'undefined') {
+  const unsubFinishHydration = useProjectManagerStore.persist.onFinishHydration((state) => {
+    if (state.currentProjectId) {
+      const data = readProjectData(state.currentProjectId)
+      if (data) {
+        isLoadingProject = true
+        useProjectStore.getState().loadProjectData(data)
+        isLoadingProject = false
+      }
+    }
+    unsubFinishHydration()
+  })
+}

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -13,6 +13,7 @@ import type {
   InsertModifierParams,
   LidModifierParams,
   ModifierContext,
+  ProjectData,
 } from '@/types/gridfinity'
 import {
   DEFAULT_BASEPLATE_PARAMS,
@@ -44,6 +45,7 @@ interface ProjectStore {
   addModifier: (parentId: string, kind: ModifierKind) => string
   updateModifierParams: (id: string, params: AnyModifierParams) => void
   removeModifier: (id: string) => void
+  loadProjectData: (data: ProjectData) => void
   getModifiersForParent: (parentId: string) => Modifier[]
   getRootObjectId: (modifierId: string) => string | null
   getModifierContext: (parentId: string) => ModifierContext | null
@@ -73,6 +75,18 @@ function getDefaultModifierParams(kind: ModifierKind): Modifier['params'] {
     case 'lid':
       return { ...DEFAULT_LID_PARAMS }
   }
+}
+
+export function resetObjectCounter(objects: GridfinityObject[]): void {
+  let maxCounter = 0
+  for (const obj of objects) {
+    const match = obj.name.match(/\s(\d+)$/)
+    if (match) {
+      const n = parseInt(match[1], 10)
+      if (n > maxCounter) maxCounter = n
+    }
+  }
+  objectCounter = maxCounter
 }
 
 function collectDescendantModifierIds(modifiers: Modifier[], rootId: string): Set<string> {
@@ -162,6 +176,11 @@ export const useProjectStore = create<ProjectStore>()((set, get) => ({
 
   clearObjects: () => {
     set({ objects: [], modifiers: [] })
+  },
+
+  loadProjectData: (data: ProjectData) => {
+    resetObjectCounter(data.objects)
+    set({ objects: data.objects, modifiers: data.modifiers })
   },
 
   addModifier: (parentId: string, kind: ModifierKind) => {

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -4,7 +4,9 @@ import type {
   LightingPreset,
   CameraPreset,
   AppView,
+  CurveQuality,
 } from '@/types/gridfinity'
+import { setCurveQuality as setPrimitivesCurveQuality } from '@/engine/geometry/primitives'
 
 interface UIStore {
   selectedObjectId: string | null
@@ -18,6 +20,8 @@ interface UIStore {
   activeView: AppView
   printBedPreset: string
   printBedSpacing: number
+  exportScale: number
+  curveQuality: CurveQuality
   selectObject: (id: string | null) => void
   toggleLeftPanel: () => void
   toggleRightPanel: () => void
@@ -31,6 +35,8 @@ interface UIStore {
   setActiveView: (view: AppView) => void
   setPrintBedPreset: (key: string) => void
   setPrintBedSpacing: (spacing: number) => void
+  setExportScale: (scale: number) => void
+  setCurveQuality: (quality: CurveQuality) => void
 }
 
 export const useUIStore = create<UIStore>()((set) => ({
@@ -45,6 +51,8 @@ export const useUIStore = create<UIStore>()((set) => ({
   activeView: 'edit',
   printBedPreset: '256x256',
   printBedSpacing: 10,
+  exportScale: 1.0,
+  curveQuality: 'medium',
 
   selectObject: (id) => {
     set({ selectedObjectId: id })
@@ -96,5 +104,14 @@ export const useUIStore = create<UIStore>()((set) => ({
 
   setPrintBedSpacing: (spacing) => {
     set({ printBedSpacing: spacing })
+  },
+
+  setExportScale: (scale) => {
+    set({ exportScale: scale })
+  },
+
+  setCurveQuality: (quality) => {
+    setPrimitivesCurveQuality(quality)
+    set({ curveQuality: quality })
   },
 }))

--- a/src/types/gridfinity.ts
+++ b/src/types/gridfinity.ts
@@ -142,3 +142,21 @@ export interface PrintBedPreset {
   width: number // mm
   depth: number // mm
 }
+
+// --- Project persistence ---
+
+export interface ProjectMeta {
+  id: string
+  name: string
+  createdAt: string // ISO 8601
+  updatedAt: string // ISO 8601
+}
+
+export interface ProjectData {
+  objects: GridfinityObject[]
+  modifiers: Modifier[]
+}
+
+// --- Export settings ---
+
+export type CurveQuality = 'low' | 'medium' | 'high'


### PR DESCRIPTION
## Summary
This PR adds comprehensive project management and export configuration features to React-Finity, enabling users to save, load, and manage projects with automatic persistence, as well as configure export parameters like scale and polygon quality.

## Key Changes

### Project Management System
- **New `projectManagerStore`**: Zustand store with persist middleware for managing project lifecycle
  - Save/load projects to localStorage with metadata (name, creation/update timestamps)
  - Auto-save functionality with 2-second debounce to prevent excessive writes
  - Project CRUD operations (create, rename, delete)
  - Tracks dirty state to indicate unsaved changes
  
- **ProjectDialog component**: Modal UI for browsing, loading, renaming, and deleting saved projects
  - Displays projects sorted by most recently updated
  - Inline rename with keyboard shortcuts (Enter to confirm, Escape to cancel)
  - Confirmation flow for destructive operations

### Toolbar Enhancements
- New "Project" dropdown menu with options:
  - New Project (clears current work)
  - Save (persists to localStorage)
  - Save As (creates named copy)
  - Manage Projects (opens project browser dialog)
- Project name display with dirty indicator (asterisk when unsaved)
- Integrated with existing export and view controls

### Export Settings
- **Export Scale**: Slider control (50-200%) to scale exported STL geometry
  - Applied during export via geometry scaling in `stlExporter.ts`
- **Polygon Quality**: Dropdown selector (Low/Medium/High) controlling curve segment resolution
  - Maps to segment counts: Low=4, Medium=8, High=16
  - Affects all curved geometry generation via `setCurveQuality()` in primitives module
  - Persisted in UIStore

### Data Persistence
- **ProjectData type**: Serializable structure containing objects and modifiers arrays
- **loadProjectData method**: Added to projectStore to hydrate state from saved projects
- **Object counter reset**: Ensures new objects get correct sequential names after loading
- Auto-load on app initialization via persist middleware hydration hook

### UI Components
- New `Dialog` component (Radix UI wrapper) for project management modal
- New `Input` component for text fields in rename/save-as dialogs
- Integrated with existing `ScrollArea` and `Separator` components

## Implementation Details

- **Auto-save debouncing**: Prevents localStorage thrashing when rapidly modifying objects
- **Load-time flag**: `isLoadingProject` prevents auto-save from triggering during project load operations
- **Metadata tracking**: Projects store creation and update timestamps in ISO 8601 format
- **Export scale integration**: Geometry scaling applied at export time without modifying scene state
- **Curve quality propagation**: Quality setting flows from UIStore → primitives module → geometry generation

## Testing
- Unit tests for projectManagerStore covering save, load, rename, delete, and auto-save
- Unit tests for projectStore's loadProjectData and object counter reset
- E2E tests for project management workflows and export settings UI
- E2E tests for export functionality with scale parameter

https://claude.ai/code/session_012HK5m6SedXJDFTgE3Rh4PL