### PR TITLE
Add mobile-responsive UI with sheet overlays for panels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ src/
 │   │   └── __tests__/     # Unit tests for export modules
 │   ├── constants.ts       # Dimension profiles, default params, print bed presets
 │   └── snapping.ts        # Grid snapping logic
-├── hooks/                 # Custom React hooks (keyboard shortcuts)
+├── hooks/                 # Custom React hooks (keyboard shortcuts, mobile detection)
 ├── store/                 # Zustand stores (project, UI, profile, project manager)
 │   └── __tests__/         # Unit tests for stores
 ├── types/                 # TypeScript interfaces
@@ -66,6 +66,7 @@ docs/                      # Architecture decision records & research documents
 - **View mode system**: The app has two views — Edit (design with panels + viewport) and Print Layout (print bed preview + export). `activeView` in `uiStore` controls which view is rendered. The toolbar shows a toggle and conditionally renders view-specific controls.
 - **Export pipeline**: `mergeObjectGeometry.ts` merges an object with all its modifiers into a single `BufferGeometry`. `printOrientation.ts` computes the optimal FDM print rotation. `printLayout.ts` arranges objects on a virtual print bed. `stlExporter.ts` exports to binary STL with optional ZIP bundling and configurable scale factor.
 - **Shared geometry functions**: `generateModifierGeometry()` and `computeBinContext()` are defined in `src/engine/export/mergeObjectGeometry.ts` and imported by both `SceneObject.tsx` (for viewport rendering) and the export pipeline (for merging). Avoid duplicating these.
+- **Responsive design**: The `md:` breakpoint (768px) divides mobile from desktop. The `useIsMobile()` hook in `src/hooks/useIsMobile.ts` provides JS-level detection via `matchMedia`. On mobile, panels render as Sheet overlays (`src/components/ui/sheet.tsx`) instead of inline sidebars; the toolbar collapses secondary actions (camera presets, snap-to-grid, viewport settings, project dropdown) into an overflow menu. All interactive elements use responsive Tailwind classes (e.g., `h-9 w-9 md:h-7 md:w-7`) to meet minimum touch target sizes on mobile.
 - **Path alias**: `@/` maps to `src/` (configured in vite.config.ts and tsconfig)
 
 ### Adding a New Object Kind

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A browser-based parametric 3D modeling application for the [Gridfinity](https://
 - **Camera presets** -- top, front, side, and isometric views
 - **Dimension profiles** -- Official, Tight Fit, and Loose Fit presets for all Gridfinity dimensions
 - **Keyboard shortcuts** -- Delete/Backspace to remove, Escape to deselect, Ctrl+P for print layout, Ctrl+Shift+E to export, Ctrl+S to save
+- **Mobile-responsive layout** -- panels slide in as overlay sheets on small screens, toolbar collapses secondary actions into overflow menu, touch-friendly button sizes
 
 ## Tech Stack
 

--- a/e2e/mobile-responsive.spec.ts
+++ b/e2e/mobile-responsive.spec.ts
@@ -1,0 +1,182 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Mobile Responsive', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    await page.goto('/')
+  })
+
+  test('panels are hidden by default on mobile', async ({ page }) => {
+    // On mobile, panels should not be visible (they are overlay sheets, closed by default)
+    await expect(page.locator('canvas')).toBeVisible()
+    await expect(
+      page.getByText('No objects yet. Use "Add Object" to get started.'),
+    ).not.toBeVisible()
+    await expect(page.getByText('Select an object to view its properties.')).not.toBeVisible()
+  })
+
+  test('left panel opens as overlay sheet', async ({ page }) => {
+    // Click the left panel toggle (first button in toolbar)
+    const leftToggle = page.locator('[data-testid="toolbar"] > button').first()
+    await leftToggle.click()
+
+    // Object list panel should appear as an overlay
+    await expect(page.getByText('No objects yet. Use "Add Object" to get started.')).toBeVisible()
+
+    // Canvas should still exist behind the overlay
+    await expect(page.locator('canvas')).toBeVisible()
+  })
+
+  test('right panel opens as overlay sheet', async ({ page }) => {
+    const rightToggle = page.locator('[data-testid="toolbar"] > button').last()
+    await rightToggle.click()
+
+    await expect(page.getByText('Select an object to view its properties.')).toBeVisible()
+  })
+
+  test('only one panel open at a time on mobile', async ({ page }) => {
+    // Open right panel
+    const rightToggle = page.locator('[data-testid="toolbar"] > button').last()
+    await rightToggle.click()
+    await expect(page.getByText('Select an object to view its properties.')).toBeVisible()
+
+    // Close it via Escape
+    await page.keyboard.press('Escape')
+    await expect(page.getByText('Select an object to view its properties.')).not.toBeVisible()
+
+    // Open left panel
+    const leftToggle = page.locator('[data-testid="toolbar"] > button').first()
+    await leftToggle.click()
+    await expect(page.getByText('No objects yet. Use "Add Object" to get started.')).toBeVisible()
+
+    // Right panel should still be closed
+    await expect(page.getByText('Select an object to view its properties.')).not.toBeVisible()
+  })
+
+  test('sheet closes when pressing Escape', async ({ page }) => {
+    // Open left panel
+    const leftToggle = page.locator('[data-testid="toolbar"] > button').first()
+    await leftToggle.click()
+    await expect(page.getByText('No objects yet. Use "Add Object" to get started.')).toBeVisible()
+
+    // Press Escape to close
+    await page.keyboard.press('Escape')
+    await expect(
+      page.getByText('No objects yet. Use "Add Object" to get started.'),
+    ).not.toBeVisible()
+  })
+
+  test('sheet closes when clicking overlay backdrop', async ({ page }) => {
+    // Open right panel
+    const rightToggle = page.locator('[data-testid="toolbar"] > button').last()
+    await rightToggle.click()
+    await expect(page.getByText('Select an object to view its properties.')).toBeVisible()
+
+    // Click the overlay backdrop to close (click far left side, away from the right sheet)
+    await page.mouse.click(10, 400)
+    await expect(page.getByText('Select an object to view its properties.')).not.toBeVisible()
+  })
+
+  test('overflow menu is visible on mobile', async ({ page }) => {
+    await expect(page.getByRole('button', { name: 'More options' })).toBeVisible()
+  })
+
+  test('overflow menu contains camera presets', async ({ page }) => {
+    await page.getByRole('button', { name: 'More options' }).click()
+    await expect(page.getByRole('menuitem', { name: 'Top View' })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: 'Front View' })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: 'Side View' })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: 'Isometric View' })).toBeVisible()
+  })
+
+  test('overflow menu contains snap to grid toggle', async ({ page }) => {
+    await page.getByRole('button', { name: 'More options' }).click()
+    await expect(page.getByRole('menuitem', { name: /Snap to Grid/i })).toBeVisible()
+  })
+
+  test('overflow menu contains project operations', async ({ page }) => {
+    await page.getByRole('button', { name: 'More options' }).click()
+    await expect(page.getByRole('menuitem', { name: 'New Project' })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: 'Save Project' })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: 'Save As...' })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: 'Manage Projects...' })).toBeVisible()
+  })
+
+  test('add object works on mobile', async ({ page }) => {
+    // Click Add button (mobile shows "Add" instead of "Add Object")
+    await page.getByRole('button', { name: /Add/i }).click()
+    await page.getByRole('menuitem', { name: 'Bin' }).click()
+
+    // Open right panel to see properties
+    const rightToggle = page.locator('[data-testid="toolbar"] > button').last()
+    await rightToggle.click()
+    await expect(page.getByText('Bin 1')).toBeVisible()
+  })
+
+  test('object list delete buttons are visible without hover on mobile', async ({ page }) => {
+    // Add an object first
+    await page.getByRole('button', { name: /Add/i }).click()
+    await page.getByRole('menuitem', { name: 'Baseplate' }).click()
+
+    // Open left panel
+    const leftToggle = page.locator('[data-testid="toolbar"] > button').first()
+    await leftToggle.click()
+
+    // The delete button should be visible without hover
+    const objectItem = page.locator('.group').filter({ hasText: 'Baseplate 1' })
+    await expect(objectItem).toBeVisible()
+    const deleteBtn = objectItem.getByRole('button')
+    await expect(deleteBtn).toBeVisible()
+  })
+
+  test('project name is hidden on mobile', async ({ page }) => {
+    await expect(page.getByTestId('project-name')).not.toBeVisible()
+  })
+
+  test('camera presets are not shown as individual buttons on mobile', async ({ page }) => {
+    // Camera preset buttons should not be in the toolbar on mobile
+    await expect(page.getByRole('button', { name: 'Top View' })).not.toBeVisible()
+    await expect(page.getByRole('button', { name: 'Front View' })).not.toBeVisible()
+  })
+
+  test('toolbar has taller height on mobile', async ({ page }) => {
+    const toolbar = page.locator('[data-testid="toolbar"]')
+    const box = await toolbar.boundingBox()
+    expect(box).not.toBeNull()
+    if (box) {
+      // h-12 = 48px on mobile (vs h-10 = 40px on desktop)
+      expect(box.height).toBeGreaterThanOrEqual(44)
+    }
+  })
+})
+
+test.describe('Desktop Responsive (unchanged behavior)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 })
+    await page.goto('/')
+  })
+
+  test('panels are visible inline by default', async ({ page }) => {
+    await expect(page.getByText('Objects', { exact: true })).toBeVisible()
+    await expect(page.getByText('Properties', { exact: true })).toBeVisible()
+  })
+
+  test('overflow menu is not visible on desktop', async ({ page }) => {
+    await expect(page.getByRole('button', { name: 'More options' })).not.toBeVisible()
+  })
+
+  test('project name is visible on desktop', async ({ page }) => {
+    await expect(page.getByTestId('project-name')).toBeVisible()
+  })
+
+  test('camera preset buttons are visible on desktop', async ({ page }) => {
+    await expect(page.getByRole('button', { name: 'Top View' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Front View' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Side View' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Isometric View' })).toBeVisible()
+  })
+
+  test('project dropdown is visible on desktop', async ({ page }) => {
+    await expect(page.getByRole('button', { name: /Project/i })).toBeVisible()
+  })
+})

--- a/e2e/panels.spec.ts
+++ b/e2e/panels.spec.ts
@@ -7,14 +7,10 @@ test.describe('Panel Toggle', () => {
 
   test('left panel is visible by default', async ({ page }) => {
     await expect(page.getByText('Objects', { exact: true })).toBeVisible()
-    await expect(
-      page.getByText('No objects yet. Use "Add Object" to get started.'),
-    ).toBeVisible()
+    await expect(page.getByText('No objects yet. Use "Add Object" to get started.')).toBeVisible()
   })
 
-  test('clicking left panel toggle hides the Objects panel', async ({
-    page,
-  }) => {
+  test('clicking left panel toggle hides the Objects panel', async ({ page }) => {
     // The left panel toggle is the first icon button (PanelLeft icon)
     const leftToggle = page.locator('button').first()
     await leftToggle.click()
@@ -25,9 +21,7 @@ test.describe('Panel Toggle', () => {
     ).not.toBeVisible()
   })
 
-  test('clicking left panel toggle twice restores the Objects panel', async ({
-    page,
-  }) => {
+  test('clicking left panel toggle twice restores the Objects panel', async ({ page }) => {
     const leftToggle = page.locator('button').first()
 
     // Hide
@@ -38,54 +32,38 @@ test.describe('Panel Toggle', () => {
 
     // Show again
     await leftToggle.click()
-    await expect(
-      page.getByText('No objects yet. Use "Add Object" to get started.'),
-    ).toBeVisible()
+    await expect(page.getByText('No objects yet. Use "Add Object" to get started.')).toBeVisible()
   })
 
   test('right panel is visible by default', async ({ page }) => {
-    await expect(
-      page.getByText('Properties', { exact: true }),
-    ).toBeVisible()
-    await expect(
-      page.getByText('Select an object to view its properties.'),
-    ).toBeVisible()
+    await expect(page.getByText('Properties', { exact: true })).toBeVisible()
+    await expect(page.getByText('Select an object to view its properties.')).toBeVisible()
   })
 
-  test('clicking right panel toggle hides the Properties panel', async ({
-    page,
-  }) => {
+  test('clicking right panel toggle hides the Properties panel', async ({ page }) => {
     // The right panel toggle is the last button in the toolbar
-    const rightToggle = page.locator('.flex.h-10 > button').last()
+    const rightToggle = page.locator('[data-testid="toolbar"] > button').last()
     await rightToggle.click()
 
     // Properties panel content should not be visible
-    await expect(
-      page.getByText('Select an object to view its properties.'),
-    ).not.toBeVisible()
+    await expect(page.getByText('Select an object to view its properties.')).not.toBeVisible()
   })
 
-  test('clicking right panel toggle twice restores the Properties panel', async ({
-    page,
-  }) => {
-    const rightToggle = page.locator('.flex.h-10 > button').last()
+  test('clicking right panel toggle twice restores the Properties panel', async ({ page }) => {
+    const rightToggle = page.locator('[data-testid="toolbar"] > button').last()
 
     // Hide
     await rightToggle.click()
-    await expect(
-      page.getByText('Select an object to view its properties.'),
-    ).not.toBeVisible()
+    await expect(page.getByText('Select an object to view its properties.')).not.toBeVisible()
 
     // Show again
     await rightToggle.click()
-    await expect(
-      page.getByText('Select an object to view its properties.'),
-    ).toBeVisible()
+    await expect(page.getByText('Select an object to view its properties.')).toBeVisible()
   })
 
   test('both panels can be collapsed simultaneously', async ({ page }) => {
     const leftToggle = page.locator('button').first()
-    const rightToggle = page.locator('.flex.h-10 > button').last()
+    const rightToggle = page.locator('[data-testid="toolbar"] > button').last()
 
     // Collapse both
     await leftToggle.click()
@@ -95,9 +73,7 @@ test.describe('Panel Toggle', () => {
     await expect(
       page.getByText('No objects yet. Use "Add Object" to get started.'),
     ).not.toBeVisible()
-    await expect(
-      page.getByText('Select an object to view its properties.'),
-    ).not.toBeVisible()
+    await expect(page.getByText('Select an object to view its properties.')).not.toBeVisible()
 
     // Canvas should still be visible
     await expect(page.locator('canvas')).toBeVisible()

--- a/src/app/Layout.tsx
+++ b/src/app/Layout.tsx
@@ -1,21 +1,43 @@
+import { useEffect, useRef } from 'react'
 import { Toolbar } from '@/components/toolbar/Toolbar'
 import { ObjectListPanel } from '@/components/panels/ObjectListPanel'
 import { PropertiesPanel } from '@/components/panels/PropertiesPanel'
 import { PrintSettingsPanel } from '@/components/panels/PrintSettingsPanel'
 import { Viewport } from '@/components/viewport/Viewport'
 import { PrintLayoutViewport } from '@/components/viewport/PrintLayoutViewport'
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
 import { useUIStore } from '@/store/uiStore'
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
+import { useIsMobile } from '@/hooks/useIsMobile'
 import { cn } from '@/lib/utils'
 
 export function Layout() {
   const leftPanelOpen = useUIStore((s) => s.leftPanelOpen)
   const rightPanelOpen = useUIStore((s) => s.rightPanelOpen)
+  const setLeftPanelOpen = useUIStore((s) => s.setLeftPanelOpen)
+  const setRightPanelOpen = useUIStore((s) => s.setRightPanelOpen)
   const activeView = useUIStore((s) => s.activeView)
+  const isMobile = useIsMobile()
+  const prevIsMobile = useRef<boolean | null>(null)
 
   useKeyboardShortcuts()
 
   const isEditView = activeView === 'edit'
+
+  // Auto-collapse panels when on mobile, re-open when switching to desktop
+  useEffect(() => {
+    if (prevIsMobile.current === null || isMobile !== prevIsMobile.current) {
+      if (isMobile) {
+        setLeftPanelOpen(false)
+        setRightPanelOpen(false)
+      } else if (prevIsMobile.current !== null) {
+        // Only re-open panels on transition from mobile to desktop, not on initial desktop mount
+        setLeftPanelOpen(true)
+        setRightPanelOpen(true)
+      }
+      prevIsMobile.current = isMobile
+    }
+  }, [isMobile, setLeftPanelOpen, setRightPanelOpen])
 
   return (
     <div className="flex h-full flex-col">
@@ -24,8 +46,8 @@ export function Layout() {
 
       {/* Main content area */}
       <div className="flex flex-1 overflow-hidden">
-        {/* Left panel - Object list (edit view only) */}
-        {isEditView && (
+        {/* Desktop: Left panel - Object list (edit view only) */}
+        {!isMobile && isEditView && (
           <div
             className={cn(
               'border-r border-border bg-background transition-all duration-200',
@@ -37,20 +59,56 @@ export function Layout() {
         )}
 
         {/* Center - 3D Viewport */}
-        <div className="flex-1">
-          {isEditView ? <Viewport /> : <PrintLayoutViewport />}
-        </div>
+        <div className="flex-1">{isEditView ? <Viewport /> : <PrintLayoutViewport />}</div>
 
-        {/* Right panel - Properties (edit) or Print Settings (print layout) */}
-        <div
-          className={cn(
-            'border-l border-border bg-background transition-all duration-200',
-            rightPanelOpen ? 'w-72' : 'w-0',
-          )}
-        >
-          {rightPanelOpen && (isEditView ? <PropertiesPanel /> : <PrintSettingsPanel />)}
-        </div>
+        {/* Desktop: Right panel - Properties (edit) or Print Settings (print layout) */}
+        {!isMobile && (
+          <div
+            className={cn(
+              'border-l border-border bg-background transition-all duration-200',
+              rightPanelOpen ? 'w-72' : 'w-0',
+            )}
+          >
+            {rightPanelOpen && (isEditView ? <PropertiesPanel /> : <PrintSettingsPanel />)}
+          </div>
+        )}
       </div>
+
+      {/* Mobile: Left panel as sheet overlay */}
+      {isMobile && isEditView && (
+        <Sheet
+          open={leftPanelOpen}
+          onOpenChange={(open) => {
+            setLeftPanelOpen(open)
+            if (open) setRightPanelOpen(false)
+          }}
+        >
+          <SheetContent side="left" className="w-60 p-0">
+            <SheetHeader className="sr-only">
+              <SheetTitle>Objects</SheetTitle>
+            </SheetHeader>
+            <ObjectListPanel />
+          </SheetContent>
+        </Sheet>
+      )}
+
+      {/* Mobile: Right panel as sheet overlay */}
+      {isMobile && (
+        <Sheet
+          open={rightPanelOpen}
+          onOpenChange={(open) => {
+            setRightPanelOpen(open)
+            if (open) setLeftPanelOpen(false)
+          }}
+        >
+          <SheetContent side="right" className="w-72 p-0">
+            <SheetHeader className="sr-only">
+              <SheetTitle>{isEditView ? 'Properties' : 'Print Settings'}</SheetTitle>
+            </SheetHeader>
+            {isEditView ? <PropertiesPanel /> : <PrintSettingsPanel />}
+          </SheetContent>
+        </Sheet>
+      )}
     </div>
   )
 }

--- a/src/components/panels/ModifierSection.tsx
+++ b/src/components/panels/ModifierSection.tsx
@@ -49,8 +49,13 @@ export function ModifierSection({ parentId, depth = 0 }: ModifierSectionProps) {
         </Label>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button variant="ghost" size="icon" className="h-6 w-6" data-testid="add-modifier-btn">
-              <Plus className="h-3 w-3" />
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 md:h-6 md:w-6"
+              data-testid="add-modifier-btn"
+            >
+              <Plus className="h-4 w-4 md:h-3 md:w-3" />
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent>
@@ -111,11 +116,11 @@ function ModifierCard({ modifier, depth, onRemove }: ModifierCardProps) {
         <Button
           variant="ghost"
           size="icon"
-          className="h-5 w-5"
+          className="h-7 w-7 md:h-5 md:w-5"
           onClick={onRemove}
           data-testid="remove-modifier-btn"
         >
-          <X className="h-3 w-3" />
+          <X className="h-4 w-4 md:h-3 md:w-3" />
         </Button>
       </div>
 

--- a/src/components/panels/ObjectListPanel.tsx
+++ b/src/components/panels/ObjectListPanel.tsx
@@ -38,7 +38,7 @@ export function ObjectListPanel() {
                 <div
                   key={obj.id}
                   className={cn(
-                    'group flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm',
+                    'group flex cursor-pointer items-center gap-2 rounded-md px-2 py-2.5 text-sm md:py-1.5',
                     isSelected ? 'bg-accent text-accent-foreground' : 'hover:bg-muted',
                   )}
                   onClick={() => {
@@ -50,7 +50,7 @@ export function ObjectListPanel() {
                   <Button
                     variant="ghost"
                     size="icon"
-                    className="h-5 w-5 opacity-0 group-hover:opacity-100"
+                    className="h-8 w-8 opacity-100 md:h-5 md:w-5 md:opacity-0 md:group-hover:opacity-100"
                     onClick={(e) => {
                       e.stopPropagation()
                       if (selectedObjectId === obj.id) {
@@ -59,7 +59,7 @@ export function ObjectListPanel() {
                       removeObject(obj.id)
                     }}
                   >
-                    <Trash2 className="h-3 w-3" />
+                    <Trash2 className="h-4 w-4 md:h-3 md:w-3" />
                   </Button>
                 </div>
               )

--- a/src/components/panels/PrintSettingsPanel.tsx
+++ b/src/components/panels/PrintSettingsPanel.tsx
@@ -19,7 +19,11 @@ import { PRINT_BED_PRESETS } from '@/engine/constants'
 import { computePrintLayout, disposePrintLayout } from '@/engine/export/printLayout'
 import { mergeObjectWithModifiers } from '@/engine/export/mergeObjectGeometry'
 import { getPrintRotation, applyPrintOrientation } from '@/engine/export/printOrientation'
-import { exportObjectAsSTL, exportAllAsZip, exportAllAsSingleSTL } from '@/engine/export/stlExporter'
+import {
+  exportObjectAsSTL,
+  exportAllAsZip,
+  exportAllAsSingleSTL,
+} from '@/engine/export/stlExporter'
 import type { CurveQuality } from '@/types/gridfinity'
 
 export function PrintSettingsPanel() {
@@ -39,12 +43,21 @@ export function PrintSettingsPanel() {
 
   const layoutItems = useMemo(() => {
     if (objects.length === 0) return []
-    return computePrintLayout(objects, modifiers, activeProfile, bed.width, bed.depth, printBedSpacing)
+    return computePrintLayout(
+      objects,
+      modifiers,
+      activeProfile,
+      bed.width,
+      bed.depth,
+      printBedSpacing,
+    )
   }, [objects, modifiers, activeProfile, bed.width, bed.depth, printBedSpacing])
 
   // Dispose on recompute
   useMemo(() => {
-    return () => { disposePrintLayout(layoutItems) }
+    return () => {
+      disposePrintLayout(layoutItems)
+    }
   }, [layoutItems])
 
   const allFit = layoutItems.every((item) => item.fitsOnBed)
@@ -107,7 +120,9 @@ export function PrintSettingsPanel() {
               max={30}
               step={1}
               value={[printBedSpacing]}
-              onValueChange={([v]) => { setPrintBedSpacing(v) }}
+              onValueChange={([v]) => {
+                setPrintBedSpacing(v)
+              }}
               aria-label="Object spacing"
             />
           </div>
@@ -127,14 +142,21 @@ export function PrintSettingsPanel() {
               max={10}
               step={0.1}
               value={[exportScale]}
-              onValueChange={([v]) => { setExportScale(Math.round(v * 10) / 10) }}
+              onValueChange={([v]) => {
+                setExportScale(Math.round(v * 10) / 10)
+              }}
               aria-label="Export scale"
             />
           </div>
 
           <div className="space-y-2">
             <Label className="text-xs">Polygon Quality</Label>
-            <Select value={curveQuality} onValueChange={(v) => { setCurveQuality(v as CurveQuality) }}>
+            <Select
+              value={curveQuality}
+              onValueChange={(v) => {
+                setCurveQuality(v as CurveQuality)
+              }}
+            >
               <SelectTrigger className="h-8 text-xs" aria-label="Polygon quality">
                 <SelectValue />
               </SelectTrigger>
@@ -177,11 +199,13 @@ export function PrintSettingsPanel() {
                     <Button
                       variant="ghost"
                       size="icon"
-                      className="h-6 w-6 shrink-0"
-                      onClick={() => { handleExportOne(item.object.id) }}
+                      className="h-8 w-8 shrink-0 md:h-6 md:w-6"
+                      onClick={() => {
+                        handleExportOne(item.object.id)
+                      }}
                       aria-label={`Export ${item.object.name}`}
                     >
-                      <Download className="h-3 w-3" />
+                      <Download className="h-4 w-4 md:h-3 md:w-3" />
                     </Button>
                   </div>
                 ))}

--- a/src/components/toolbar/CameraPresets.tsx
+++ b/src/components/toolbar/CameraPresets.tsx
@@ -23,7 +23,7 @@ export function CameraPresets() {
               <Button
                 variant="ghost"
                 size="icon"
-                className="h-7 w-7"
+                className="h-9 w-9 md:h-7 md:w-7"
                 onClick={() => {
                   setCameraPreset(preset)
                 }}

--- a/src/components/toolbar/Toolbar.tsx
+++ b/src/components/toolbar/Toolbar.tsx
@@ -1,7 +1,17 @@
 import { useState } from 'react'
 import {
-  Plus, PanelLeft, PanelRight, Grid3x3, Download, Pencil, Printer,
-  FolderOpen, Save, FilePlus, FolderCog,
+  Plus,
+  PanelLeft,
+  PanelRight,
+  Grid3x3,
+  Download,
+  Pencil,
+  Printer,
+  FolderOpen,
+  Save,
+  FilePlus,
+  FolderCog,
+  MoreHorizontal,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
@@ -10,6 +20,12 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
 } from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { CameraPresets } from './CameraPresets'
@@ -19,10 +35,12 @@ import { useProjectStore } from '@/store/projectStore'
 import { useProfileStore } from '@/store/profileStore'
 import { useUIStore } from '@/store/uiStore'
 import { useProjectManagerStore } from '@/store/projectManagerStore'
+import { useIsMobile } from '@/hooks/useIsMobile'
 import { cn } from '@/lib/utils'
 import { mergeObjectWithModifiers } from '@/engine/export/mergeObjectGeometry'
 import { getPrintRotation, applyPrintOrientation } from '@/engine/export/printOrientation'
 import { exportObjectAsSTL } from '@/engine/export/stlExporter'
+import type { ViewportBackground, LightingPreset, CameraPreset } from '@/types/gridfinity'
 
 export function Toolbar() {
   const addObject = useProjectStore((s) => s.addObject)
@@ -37,6 +55,11 @@ export function Toolbar() {
   const activeView = useUIStore((s) => s.activeView)
   const setActiveView = useUIStore((s) => s.setActiveView)
   const exportScale = useUIStore((s) => s.exportScale)
+  const setCameraPreset = useUIStore((s) => s.setCameraPreset)
+  const viewportBackground = useUIStore((s) => s.viewportBackground)
+  const setViewportBackground = useUIStore((s) => s.setViewportBackground)
+  const lightingPreset = useUIStore((s) => s.lightingPreset)
+  const setLightingPreset = useUIStore((s) => s.setLightingPreset)
   const activeProfile = useProfileStore((s) => s.activeProfile)
 
   const currentProjectName = useProjectManagerStore((s) => s.currentProjectName)
@@ -48,6 +71,8 @@ export function Toolbar() {
   const [projectDialogOpen, setProjectDialogOpen] = useState(false)
   const [saveAsPrompt, setSaveAsPrompt] = useState(false)
   const [saveAsName, setSaveAsName] = useState('')
+
+  const isMobile = useIsMobile()
 
   const handleAddBaseplate = () => {
     const id = addObject('baseplate')
@@ -89,44 +114,58 @@ export function Toolbar() {
 
   return (
     <>
-      <div className="flex h-10 items-center gap-2 border-b border-border bg-background px-3">
+      <div
+        className="flex h-12 items-center gap-2 border-b border-border bg-background px-3 md:h-10"
+        data-testid="toolbar"
+      >
         {/* Left panel toggle */}
-        <Button variant="ghost" size="icon" onClick={toggleLeftPanel} className="h-7 w-7">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={toggleLeftPanel}
+          className="h-9 w-9 md:h-7 md:w-7"
+        >
           <PanelLeft className="h-4 w-4" />
         </Button>
 
-        <div className="h-5 w-px bg-border" />
+        {!isMobile && <div className="h-5 w-px bg-border" />}
 
-        {/* Project dropdown */}
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="ghost" size="sm" className="h-7 gap-1">
-              <FolderOpen className="h-4 w-4" />
-              Project
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent>
-            <DropdownMenuItem onClick={newProject}>
-              <FilePlus className="mr-2 h-4 w-4" />
-              New Project
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={saveProject}>
-              <Save className="mr-2 h-4 w-4" />
-              Save
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={handleSaveAs}>
-              <Save className="mr-2 h-4 w-4" />
-              Save As...
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={() => { setProjectDialogOpen(true) }}>
-              <FolderCog className="mr-2 h-4 w-4" />
-              Manage Projects...
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+        {/* Project dropdown - desktop only */}
+        {!isMobile && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="sm" className="h-7 gap-1">
+                <FolderOpen className="h-4 w-4" />
+                Project
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+              <DropdownMenuItem onClick={newProject}>
+                <FilePlus className="mr-2 h-4 w-4" />
+                New Project
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={saveProject}>
+                <Save className="mr-2 h-4 w-4" />
+                Save
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={handleSaveAs}>
+                <Save className="mr-2 h-4 w-4" />
+                Save As...
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onClick={() => {
+                  setProjectDialogOpen(true)
+                }}
+              >
+                <FolderCog className="mr-2 h-4 w-4" />
+                Manage Projects...
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
 
-        <div className="h-5 w-px bg-border" />
+        {!isMobile && <div className="h-5 w-px bg-border" />}
 
         {/* View mode toggle */}
         <TooltipProvider delayDuration={300}>
@@ -137,10 +176,12 @@ export function Toolbar() {
                   variant="ghost"
                   size="sm"
                   className={cn(
-                    'h-6 gap-1 px-2 text-xs',
+                    'h-8 gap-1 px-2 text-xs md:h-6',
                     isEditView && 'bg-accent text-accent-foreground',
                   )}
-                  onClick={() => { setActiveView('edit') }}
+                  onClick={() => {
+                    setActiveView('edit')
+                  }}
                   aria-label="Edit view"
                   aria-pressed={isEditView}
                 >
@@ -156,10 +197,12 @@ export function Toolbar() {
                   variant="ghost"
                   size="sm"
                   className={cn(
-                    'h-6 gap-1 px-2 text-xs',
+                    'h-8 gap-1 px-2 text-xs md:h-6',
                     !isEditView && 'bg-accent text-accent-foreground',
                   )}
-                  onClick={() => { setActiveView('printLayout') }}
+                  onClick={() => {
+                    setActiveView('printLayout')
+                  }}
                   aria-label="Print layout view"
                   aria-pressed={!isEditView}
                 >
@@ -172,10 +215,10 @@ export function Toolbar() {
           </div>
         </TooltipProvider>
 
-        <div className="h-5 w-px bg-border" />
+        {!isMobile && <div className="h-5 w-px bg-border" />}
 
-        {/* Edit view controls */}
-        {isEditView && (
+        {/* Edit view controls - desktop */}
+        {!isMobile && isEditView && (
           <>
             {/* Add object dropdown */}
             <DropdownMenu>
@@ -219,23 +262,43 @@ export function Toolbar() {
           </>
         )}
 
+        {/* Add object dropdown - mobile */}
+        {isMobile && isEditView && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="sm" className="h-9 gap-1">
+                <Plus className="h-4 w-4" />
+                Add
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+              <DropdownMenuItem onClick={handleAddBaseplate}>Baseplate</DropdownMenuItem>
+              <DropdownMenuItem onClick={handleAddBin}>Bin</DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+
         {/* Spacer */}
         <div className="flex-1" />
 
-        {/* Project name */}
-        <span className="text-xs font-medium text-muted-foreground" data-testid="project-name">
-          {currentProjectName}{isDirty ? ' *' : ''}
+        {/* Project name - desktop only */}
+        <span
+          className="hidden text-xs font-medium text-muted-foreground md:inline"
+          data-testid="project-name"
+        >
+          {currentProjectName}
+          {isDirty ? ' *' : ''}
         </span>
 
-        {/* Spacer */}
-        <div className="flex-1" />
+        {/* Spacer - desktop only */}
+        <div className="hidden flex-1 md:block" />
 
         {/* Export dropdown */}
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button variant="ghost" size="sm" className="h-7 gap-1">
+            <Button variant="ghost" size="sm" className="h-9 gap-1 md:h-7">
               <Download className="h-4 w-4" />
-              Export
+              <span className="hidden md:inline">Export</span>
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
@@ -247,7 +310,9 @@ export function Toolbar() {
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem
-              onClick={() => { setActiveView('printLayout') }}
+              onClick={() => {
+                setActiveView('printLayout')
+              }}
               disabled={!isEditView}
             >
               Open Print Layout
@@ -255,18 +320,116 @@ export function Toolbar() {
           </DropdownMenuContent>
         </DropdownMenu>
 
-        {/* Viewport settings (edit view only) */}
-        {isEditView && (
+        {/* Viewport settings - desktop only */}
+        {!isMobile && isEditView && (
           <>
             <div className="h-5 w-px bg-border" />
             <ViewportSettings />
           </>
         )}
 
-        <div className="h-5 w-px bg-border" />
+        {/* Overflow menu - mobile only */}
+        {isMobile && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="icon" className="h-9 w-9" aria-label="More options">
+                <MoreHorizontal className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {isEditView && (
+                <>
+                  <DropdownMenuLabel>Camera</DropdownMenuLabel>
+                  <DropdownMenuItem
+                    onClick={() => {
+                      setCameraPreset('top' as CameraPreset)
+                    }}
+                  >
+                    Top View
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={() => {
+                      setCameraPreset('front' as CameraPreset)
+                    }}
+                  >
+                    Front View
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={() => {
+                      setCameraPreset('side' as CameraPreset)
+                    }}
+                  >
+                    Side View
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={() => {
+                      setCameraPreset('isometric' as CameraPreset)
+                    }}
+                  >
+                    Isometric View
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onClick={toggleSnapToGrid}>
+                    {snapToGrid ? 'Disable' : 'Enable'} Snap to Grid
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuSub>
+                    <DropdownMenuSubTrigger>Background</DropdownMenuSubTrigger>
+                    <DropdownMenuSubContent>
+                      <DropdownMenuRadioGroup
+                        value={viewportBackground}
+                        onValueChange={(v) => {
+                          setViewportBackground(v as ViewportBackground)
+                        }}
+                      >
+                        <DropdownMenuRadioItem value="dark">Dark</DropdownMenuRadioItem>
+                        <DropdownMenuRadioItem value="light">Light</DropdownMenuRadioItem>
+                        <DropdownMenuRadioItem value="neutral">Neutral</DropdownMenuRadioItem>
+                      </DropdownMenuRadioGroup>
+                    </DropdownMenuSubContent>
+                  </DropdownMenuSub>
+                  <DropdownMenuSub>
+                    <DropdownMenuSubTrigger>Lighting</DropdownMenuSubTrigger>
+                    <DropdownMenuSubContent>
+                      <DropdownMenuRadioGroup
+                        value={lightingPreset}
+                        onValueChange={(v) => {
+                          setLightingPreset(v as LightingPreset)
+                        }}
+                      >
+                        <DropdownMenuRadioItem value="studio">Studio</DropdownMenuRadioItem>
+                        <DropdownMenuRadioItem value="outdoor">Outdoor</DropdownMenuRadioItem>
+                        <DropdownMenuRadioItem value="soft">Soft</DropdownMenuRadioItem>
+                      </DropdownMenuRadioGroup>
+                    </DropdownMenuSubContent>
+                  </DropdownMenuSub>
+                  <DropdownMenuSeparator />
+                </>
+              )}
+              <DropdownMenuLabel>Project</DropdownMenuLabel>
+              <DropdownMenuItem onClick={newProject}>New Project</DropdownMenuItem>
+              <DropdownMenuItem onClick={saveProject}>Save Project</DropdownMenuItem>
+              <DropdownMenuItem onClick={handleSaveAs}>Save As...</DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => {
+                  setProjectDialogOpen(true)
+                }}
+              >
+                Manage Projects...
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+
+        {!isMobile && <div className="h-5 w-px bg-border" />}
 
         {/* Right panel toggle */}
-        <Button variant="ghost" size="icon" onClick={toggleRightPanel} className="h-7 w-7">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={toggleRightPanel}
+          className="h-9 w-9 md:h-7 md:w-7"
+        >
           <PanelRight className="h-4 w-4" />
         </Button>
       </div>
@@ -282,7 +445,9 @@ export function Toolbar() {
             <input
               type="text"
               value={saveAsName}
-              onChange={(e) => { setSaveAsName(e.target.value) }}
+              onChange={(e) => {
+                setSaveAsName(e.target.value)
+              }}
               onKeyDown={(e) => {
                 if (e.key === 'Enter') handleConfirmSaveAs()
                 if (e.key === 'Escape') setSaveAsPrompt(false)
@@ -293,7 +458,13 @@ export function Toolbar() {
               aria-label="Project name"
             />
             <div className="flex justify-end gap-2">
-              <Button variant="ghost" size="sm" onClick={() => { setSaveAsPrompt(false) }}>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setSaveAsPrompt(false)
+                }}
+              >
                 Cancel
               </Button>
               <Button size="sm" onClick={handleConfirmSaveAs} disabled={!saveAsName.trim()}>

--- a/src/components/toolbar/ViewportSettings.tsx
+++ b/src/components/toolbar/ViewportSettings.tsx
@@ -21,7 +21,12 @@ export function ViewportSettings() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon" className="h-7 w-7" aria-label="Viewport settings">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-9 w-9 md:h-7 md:w-7"
+          aria-label="Viewport settings"
+        >
           <Settings className="h-4 w-4" />
         </Button>
       </DropdownMenuTrigger>

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,124 @@
+import * as React from 'react'
+import * as SheetPrimitive from '@radix-ui/react-dialog'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { X } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+const Sheet = SheetPrimitive.Root
+
+const SheetTrigger = SheetPrimitive.Trigger
+
+const SheetClose = SheetPrimitive.Close
+
+const SheetPortal = SheetPrimitive.Portal
+
+const SheetOverlay = React.forwardRef<
+  React.ComponentRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={cn(
+      'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className,
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
+
+const sheetVariants = cva(
+  'fixed z-50 gap-4 bg-background shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
+  {
+    variants: {
+      side: {
+        top: 'inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top',
+        bottom:
+          'inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
+        left: 'inset-y-0 left-0 h-full border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left',
+        right:
+          'inset-y-0 right-0 h-full border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right',
+      },
+    },
+    defaultVariants: {
+      side: 'right',
+    },
+  },
+)
+
+interface SheetContentProps
+  extends
+    React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {}
+
+const SheetContent = React.forwardRef<
+  React.ComponentRef<typeof SheetPrimitive.Content>,
+  SheetContentProps
+>(({ side = 'right', className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </SheetPrimitive.Close>
+      {children}
+    </SheetPrimitive.Content>
+  </SheetPortal>
+))
+SheetContent.displayName = SheetPrimitive.Content.displayName
+
+function SheetHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={cn('flex flex-col space-y-2 text-center sm:text-left', className)} {...props} />
+  )
+}
+SheetHeader.displayName = 'SheetHeader'
+
+function SheetFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
+      {...props}
+    />
+  )
+}
+SheetFooter.displayName = 'SheetFooter'
+
+const SheetTitle = React.forwardRef<
+  React.ComponentRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold text-foreground', className)}
+    {...props}
+  />
+))
+SheetTitle.displayName = SheetPrimitive.Title.displayName
+
+const SheetDescription = React.forwardRef<
+  React.ComponentRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-muted-foreground', className)}
+    {...props}
+  />
+))
+SheetDescription.displayName = SheetPrimitive.Description.displayName
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetClose,
+  SheetTrigger,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}

--- a/src/components/viewport/PrintLayoutViewport.tsx
+++ b/src/components/viewport/PrintLayoutViewport.tsx
@@ -32,9 +32,7 @@ function PrintBed({ width, depth }: { width: number; depth: number }) {
 
       {/* Bed outline */}
       <lineSegments position={[width / 2, 0.05, depth / 2]}>
-        <edgesGeometry
-          args={[new THREE.PlaneGeometry(width, depth)]}
-        />
+        <edgesGeometry args={[new THREE.PlaneGeometry(width, depth)]} />
         <lineBasicMaterial color="#6b9bd2" linewidth={2} />
       </lineSegments>
 
@@ -84,7 +82,9 @@ function PrintScene() {
 
   // Dispose previous layout geometries on unmount/recompute
   useMemo(() => {
-    return () => { disposePrintLayout(layoutItems) }
+    return () => {
+      disposePrintLayout(layoutItems)
+    }
   }, [layoutItems])
 
   return (
@@ -121,7 +121,7 @@ function PrintScene() {
 
 export function PrintLayoutViewport() {
   return (
-    <div className="h-full w-full">
+    <div className="h-full w-full touch-manipulation">
       <Canvas
         camera={{
           position: [200, 300, 200],

--- a/src/components/viewport/Viewport.tsx
+++ b/src/components/viewport/Viewport.tsx
@@ -143,7 +143,7 @@ export function Viewport() {
   const bgColor = BACKGROUND_COLORS[viewportBackground]
 
   return (
-    <div className="h-full w-full">
+    <div className="h-full w-full touch-manipulation">
       <Canvas
         camera={{
           position: [200, 150, 200],

--- a/src/hooks/__tests__/useIsMobile.test.ts
+++ b/src/hooks/__tests__/useIsMobile.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useIsMobile } from '../useIsMobile'
+
+describe('useIsMobile', () => {
+  let changeListeners: (() => void)[] = []
+  let currentMatches = false
+
+  function createMatchMediaMock(matches: boolean) {
+    currentMatches = matches
+    changeListeners = []
+    return vi.fn(() => ({
+      get matches() {
+        return currentMatches
+      },
+      media: '',
+      addEventListener: (_event: string, cb: () => void) => {
+        changeListeners.push(cb)
+      },
+      removeEventListener: (_event: string, cb: () => void) => {
+        changeListeners = changeListeners.filter((l) => l !== cb)
+      },
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+  }
+
+  beforeEach(() => {
+    changeListeners = []
+    currentMatches = false
+  })
+
+  it('returns false for desktop widths', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: createMatchMediaMock(false),
+    })
+    const { result } = renderHook(() => useIsMobile())
+    expect(result.current).toBe(false)
+  })
+
+  it('returns true for mobile widths', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: createMatchMediaMock(true),
+    })
+    const { result } = renderHook(() => useIsMobile())
+    expect(result.current).toBe(true)
+  })
+
+  it('updates when media query changes', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: createMatchMediaMock(false),
+    })
+    const { result } = renderHook(() => useIsMobile())
+    expect(result.current).toBe(false)
+
+    // Simulate media query change
+    act(() => {
+      currentMatches = true
+      changeListeners.forEach((cb) => {
+        cb()
+      })
+    })
+    expect(result.current).toBe(true)
+  })
+
+  it('updates back to false when resized to desktop', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: createMatchMediaMock(true),
+    })
+    const { result } = renderHook(() => useIsMobile())
+    expect(result.current).toBe(true)
+
+    act(() => {
+      currentMatches = false
+      changeListeners.forEach((cb) => {
+        cb()
+      })
+    })
+    expect(result.current).toBe(false)
+  })
+
+  it('cleans up event listener on unmount', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: createMatchMediaMock(false),
+    })
+    const { unmount } = renderHook(() => useIsMobile())
+    expect(changeListeners.length).toBeGreaterThan(0)
+    unmount()
+    expect(changeListeners.length).toBe(0)
+  })
+})

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -1,0 +1,23 @@
+import { useSyncExternalStore } from 'react'
+
+const MOBILE_BREAKPOINT = 768
+
+function getSnapshot(): boolean {
+  return window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`).matches
+}
+
+function getServerSnapshot(): boolean {
+  return false
+}
+
+function subscribe(callback: () => void): () => void {
+  const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+  mql.addEventListener('change', callback)
+  return () => {
+    mql.removeEventListener('change', callback)
+  }
+}
+
+export function useIsMobile(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive mobile responsiveness to the application, transforming the fixed sidebar layout into a mobile-friendly design with overlay sheets for panels on smaller screens.

## Key Changes

### Mobile Detection & Responsive Layout
- Added `useIsMobile()` hook using `useSyncExternalStore` to detect viewport width (< 768px breakpoint)
- Updated `Layout.tsx` to conditionally render panels as inline sidebars (desktop) or overlay sheets (mobile)
- Auto-collapse panels when switching to mobile, re-open when returning to desktop

### Sheet Component
- Added new `Sheet` UI component built on Radix UI Dialog with slide-in/out animations
- Supports configurable sides (left, right, top, bottom) with appropriate animations
- Includes overlay backdrop and close button

### Toolbar Responsive Design
- Increased toolbar height on mobile (h-12 = 48px) vs desktop (h-10 = 40px)
- Hid desktop-only elements on mobile: project dropdown, project name display, viewport settings
- Added mobile-specific "Add" button with simplified menu (Baseplate, Bin only)
- Added overflow menu ("More options") for mobile with:
  - Camera presets (Top, Front, Side, Isometric)
  - Snap to grid toggle
  - Background and lighting preset controls
  - Project operations (New, Save, Save As, Manage)
- Adjusted button sizes for better touch targets on mobile (h-9 w-9 vs h-7 w-7)
- Hid visual separators on mobile to save space

### Panel Behavior
- Left and right panels now open as full-height overlay sheets on mobile
- Only one panel can be open at a time on mobile (opening one closes the other)
- Sheets close on Escape key or backdrop click
- Desktop behavior unchanged: panels remain inline sidebars

### Testing
- Added comprehensive E2E tests (`mobile-responsive.spec.ts`) covering:
  - Panel overlay behavior on mobile
  - Sheet open/close interactions
  - Overflow menu functionality
  - Mobile-specific UI elements visibility
  - Desktop behavior unchanged
- Added unit tests for `useIsMobile()` hook with media query mocking

### Minor Improvements
- Added `touch-manipulation` class to viewport for better mobile touch handling
- Improved code formatting consistency across modified files
- Updated type imports for viewport and lighting presets
- Added `data-testid="toolbar"` for better test selectors

## Implementation Details
- Uses React's `useSyncExternalStore` for efficient media query subscription without re-renders on every change
- Mobile breakpoint set at 768px (Tailwind's `md:` breakpoint)
- Sheet animations use Radix UI's built-in slide and fade animations
- Maintains full feature parity between mobile and desktop (all functionality accessible via overflow menu on mobile)

https://claude.ai/code/session_019SviHLhSZ9KsQfvL98x4AK