### PR TITLE
Add 3MF export support for single objects and print plates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ src/
 │   │   ├── printOrientation.ts     # Optimal FDM print orientation per object kind
 │   │   ├── printLayout.ts          # Row-based print bed layout algorithm
 │   │   ├── stlExporter.ts          # STL binary export + ZIP download
+│   │   ├── threeMfExporter.ts      # 3MF export (single + multi-object)
 │   │   └── __tests__/     # Unit tests for export modules
 │   ├── constants.ts       # Dimension profiles, default params, print bed presets
 │   └── snapping.ts        # Grid snapping logic
@@ -64,7 +65,7 @@ docs/                      # Architecture decision records & research documents
 - **Profile system**: All dimension constants come from `GridfinityProfile` objects (Official, Tight Fit, Loose Fit). Geometry generators receive the active profile, not raw constants.
 - **Properties panels**: One component per object kind (`BaseplateProperties`, `BinProperties`), following the same pattern of sliders/switches with label + value display. BinProperties includes a `ModifierSection` that renders modifier cards recursively.
 - **View mode system**: The app has two views — Edit (design with panels + viewport) and Print Layout (print bed preview + export). `activeView` in `uiStore` controls which view is rendered. The toolbar shows a toggle and conditionally renders view-specific controls.
-- **Export pipeline**: `mergeObjectGeometry.ts` merges an object with all its modifiers into a single `BufferGeometry`. `printOrientation.ts` computes the optimal FDM print rotation. `printLayout.ts` arranges objects on a virtual print bed. `stlExporter.ts` exports to binary STL with optional ZIP bundling and configurable scale factor.
+- **Export pipeline**: `mergeObjectGeometry.ts` merges an object with all its modifiers into a single `BufferGeometry`. `printOrientation.ts` computes the optimal FDM print rotation. `printLayout.ts` arranges objects on a virtual print bed. `stlExporter.ts` exports to binary STL with optional ZIP bundling and configurable scale factor. `threeMfExporter.ts` exports to 3MF format using JSZip for OPC archive creation, sharing the same `PrintLayoutItem[]` interface as the STL exporter.
 - **Shared geometry functions**: `generateModifierGeometry()` and `computeBinContext()` are defined in `src/engine/export/mergeObjectGeometry.ts` and imported by both `SceneObject.tsx` (for viewport rendering) and the export pipeline (for merging). Avoid duplicating these.
 - **Responsive design**: The `md:` breakpoint (768px) divides mobile from desktop. The `useIsMobile()` hook in `src/hooks/useIsMobile.ts` provides JS-level detection via `matchMedia`. On mobile, panels render as Sheet overlays (`src/components/ui/sheet.tsx`) instead of inline sidebars; the toolbar collapses secondary actions (camera presets, snap-to-grid, viewport settings, project dropdown) into an overflow menu. All interactive elements use responsive Tailwind classes (e.g., `h-9 w-9 md:h-7 md:w-7`) to meet minimum touch target sizes on mobile.
 - **Path alias**: `@/` maps to `src/` (configured in vite.config.ts and tsconfig)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -115,11 +115,9 @@ Long-term, the app will transition to a native desktop experience via Tauri whil
 - **Local storage persistence** — projects saved as JSON (parameters + modifiers, not geometry) to localStorage with auto-save (2s debounce after last change)
 - **Project management** — toolbar Project dropdown with New/Save/Save As/Manage. Manage Projects dialog for loading, renaming, and deleting saved projects. Projects auto-load on startup
 - **Export settings** — configurable export scale (0.1x-10x) and polygon quality (Low/Medium/High) in Print Settings panel
-- Unit tests for geometry merging, print orientation, layout algorithm, STL export, project manager store, and export settings (45+ tests)
-- E2E tests for print layout view, export functionality, project management, and export settings (39 tests)
-
-**Deferred to later phase:**
-- 3MF export via three-3mf-exporter
+- **3MF export** — single object and multi-object plate export in 3MF format using JSZip for OPC archive creation. Export Selected sub-menu (STL/3MF) in toolbar, per-object format dropdown and batch Export All (3MF) button in Print Settings panel
+- Unit tests for geometry merging, print orientation, layout algorithm, STL export, 3MF export, project manager store, and export settings (55+ tests)
+- E2E tests for print layout view, export functionality, project management, and export settings (45+ tests)
 
 ---
 

--- a/docs/slicer-export-research.md
+++ b/docs/slicer-export-research.md
@@ -35,7 +35,11 @@ From `ROADMAP.md`:
 
 ---
 
-## Tier 1: 3MF Export
+## Tier 1: 3MF Export -- Implemented
+
+> Implemented in `src/engine/export/threeMfExporter.ts`. The API provides
+> `exportObjectAs3MF()` for single-object export and `exportAllAs3MF()` for
+> multi-object plate export. Both use JSZip to produce OPC-compliant archives.
 
 ### Format Overview
 
@@ -386,7 +390,7 @@ export async function openInSlicer(app: SlicerApp, filePath: string): Promise<vo
 
 ## Recommended Implementation Sequence
 
-### Tier 1 -- 3MF Export (next)
+### Tier 1 -- 3MF Export (complete)
 
 1. Create `src/engine/export/threeMfExporter.ts` with `geometryTo3MFModelXml()`, `exportObjectAs3MF()`, `exportAllAs3MF()`
 2. Add unit tests in `src/engine/export/__tests__/threeMfExporter.test.ts`

--- a/e2e/export.spec.ts
+++ b/e2e/export.spec.ts
@@ -12,17 +12,25 @@ test.describe('Export Functionality', () => {
   test('Export dropdown shows menu items', async ({ page }) => {
     await page.getByRole('button', { name: /Export/ }).click()
 
-    await expect(page.getByRole('menuitem', { name: /Export Selected/ })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: /Export Selected \(STL\)/ })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: /Export Selected \(3MF\)/ })).toBeVisible()
     await expect(page.getByRole('menuitem', { name: /Open Print Layout/ })).toBeVisible()
   })
 
-  test('Export Selected is disabled when nothing is selected', async ({ page }) => {
+  test('Export Selected (STL) is disabled when nothing is selected', async ({ page }) => {
     await page.getByRole('button', { name: /Export/ }).click()
 
-    const exportSelected = page.getByRole('menuitem', { name: /Export Selected/ })
+    const exportSelected = page.getByRole('menuitem', { name: /Export Selected \(STL\)/ })
     await expect(exportSelected).toBeVisible()
-    // Disabled menu items have data-disabled attribute in radix
     await expect(exportSelected).toHaveAttribute('data-disabled')
+  })
+
+  test('Export Selected (3MF) is disabled when nothing is selected', async ({ page }) => {
+    await page.getByRole('button', { name: /Export/ }).click()
+
+    const export3mf = page.getByRole('menuitem', { name: /Export Selected \(3MF\)/ })
+    await expect(export3mf).toBeVisible()
+    await expect(export3mf).toHaveAttribute('data-disabled')
   })
 
   test('Open Print Layout switches to print view', async ({ page }) => {
@@ -33,7 +41,7 @@ test.describe('Export Functionality', () => {
     await expect(page.getByText('Print Settings')).toBeVisible()
   })
 
-  test('Export Selected is enabled after selecting an object', async ({ page }) => {
+  test('Export Selected (STL) is enabled after selecting an object', async ({ page }) => {
     // Add and select an object
     await page.getByRole('button', { name: /Add Object/i }).click()
     await page.getByRole('menuitem', { name: 'Baseplate' }).click()
@@ -41,12 +49,25 @@ test.describe('Export Functionality', () => {
     // Open export dropdown
     await page.getByRole('button', { name: /Export/ }).click()
 
-    // Export Selected should be enabled (no data-disabled attribute)
-    const exportSelected = page.getByRole('menuitem', { name: /Export Selected/ })
+    // Export Selected (STL) should be enabled (no data-disabled attribute)
+    const exportSelected = page.getByRole('menuitem', { name: /Export Selected \(STL\)/ })
     await expect(exportSelected).not.toHaveAttribute('data-disabled')
   })
 
-  test('Export triggers download for selected object', async ({ page }) => {
+  test('Export Selected (3MF) is enabled after selecting an object', async ({ page }) => {
+    // Add and select an object
+    await page.getByRole('button', { name: /Add Object/i }).click()
+    await page.getByRole('menuitem', { name: 'Baseplate' }).click()
+
+    // Open export dropdown
+    await page.getByRole('button', { name: /Export/ }).click()
+
+    // Export Selected (3MF) should be enabled (no data-disabled attribute)
+    const export3mf = page.getByRole('menuitem', { name: /Export Selected \(3MF\)/ })
+    await expect(export3mf).not.toHaveAttribute('data-disabled')
+  })
+
+  test('Export Selected (STL) triggers download with .stl extension', async ({ page }) => {
     // Add and select an object
     await page.getByRole('button', { name: /Add Object/i }).click()
     await page.getByRole('menuitem', { name: 'Baseplate' }).click()
@@ -54,13 +75,30 @@ test.describe('Export Functionality', () => {
     // Set up download listener
     const downloadPromise = page.waitForEvent('download')
 
-    // Export selected
+    // Export selected as STL
     await page.getByRole('button', { name: /Export/ }).click()
-    await page.getByRole('menuitem', { name: /Export Selected/ }).click()
+    await page.getByRole('menuitem', { name: /Export Selected \(STL\)/ }).click()
 
     // Should trigger a download
     const download = await downloadPromise
     expect(download.suggestedFilename()).toBe('Baseplate 1.stl')
+  })
+
+  test('Export Selected (3MF) triggers download with .3mf extension', async ({ page }) => {
+    // Add and select an object
+    await page.getByRole('button', { name: /Add Object/i }).click()
+    await page.getByRole('menuitem', { name: 'Baseplate' }).click()
+
+    // Set up download listener
+    const downloadPromise = page.waitForEvent('download')
+
+    // Export selected as 3MF
+    await page.getByRole('button', { name: /Export/ }).click()
+    await page.getByRole('menuitem', { name: /Export Selected \(3MF\)/ }).click()
+
+    // Should trigger a download
+    const download = await downloadPromise
+    expect(download.suggestedFilename()).toBe('Baseplate 1.3mf')
   })
 
   test('Ctrl+P toggles to print layout view', async ({ page }) => {

--- a/e2e/print-layout.spec.ts
+++ b/e2e/print-layout.spec.ts
@@ -70,9 +70,7 @@ test.describe('Print Layout View', () => {
   test('shows empty state when no objects exist', async ({ page }) => {
     await page.getByRole('button', { name: 'Print layout view' }).click()
 
-    await expect(
-      page.getByText('No objects to export. Add objects in Edit view.'),
-    ).toBeVisible()
+    await expect(page.getByText('No objects to export. Add objects in Edit view.')).toBeVisible()
   })
 
   test('shows objects in print settings after adding in edit view', async ({ page }) => {
@@ -135,5 +133,55 @@ test.describe('Print Layout View', () => {
 
     // Verify selection changed (the trigger should show the new value)
     await expect(page.getByText('220 x 220 mm')).toBeVisible()
+  })
+
+  test('shows Export All (3MF) button in print settings', async ({ page }) => {
+    await page.getByRole('button', { name: /Add Object/i }).click()
+    await page.getByRole('menuitem', { name: 'Baseplate' }).click()
+
+    await page.getByRole('button', { name: 'Print layout view' }).click()
+
+    await expect(page.getByRole('button', { name: /Export All \(3MF\)/ })).toBeVisible()
+  })
+
+  test('Export All (3MF) is disabled when no objects exist', async ({ page }) => {
+    await page.getByRole('button', { name: 'Print layout view' }).click()
+
+    await expect(page.getByRole('button', { name: /Export All \(3MF\)/ })).toBeDisabled()
+  })
+
+  test('Export All (3MF) is enabled with objects on the plate', async ({ page }) => {
+    await page.getByRole('button', { name: /Add Object/i }).click()
+    await page.getByRole('menuitem', { name: 'Baseplate' }).click()
+
+    await page.getByRole('button', { name: 'Print layout view' }).click()
+
+    await expect(page.getByRole('button', { name: /Export All \(3MF\)/ })).toBeEnabled()
+  })
+
+  test('Export All (3MF) triggers download with .3mf extension', async ({ page }) => {
+    await page.getByRole('button', { name: /Add Object/i }).click()
+    await page.getByRole('menuitem', { name: 'Baseplate' }).click()
+
+    await page.getByRole('button', { name: 'Print layout view' }).click()
+
+    const downloadPromise = page.waitForEvent('download')
+    await page.getByRole('button', { name: /Export All \(3MF\)/ }).click()
+
+    const download = await downloadPromise
+    expect(download.suggestedFilename()).toBe('react-finity-plate.3mf')
+  })
+
+  test('per-object export dropdown shows STL and 3MF options', async ({ page }) => {
+    await page.getByRole('button', { name: /Add Object/i }).click()
+    await page.getByRole('menuitem', { name: 'Baseplate' }).click()
+
+    await page.getByRole('button', { name: 'Print layout view' }).click()
+
+    // Click the per-object export button to open format dropdown
+    await page.getByRole('button', { name: /Export Baseplate 1/ }).click()
+
+    await expect(page.getByRole('menuitem', { name: /Export as STL/ })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: /Export as 3MF/ })).toBeVisible()
   })
 })

--- a/src/components/panels/PrintSettingsPanel.tsx
+++ b/src/components/panels/PrintSettingsPanel.tsx
@@ -12,6 +12,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import { useProjectStore } from '@/store/projectStore'
 import { useProfileStore } from '@/store/profileStore'
 import { useUIStore } from '@/store/uiStore'
@@ -24,6 +30,7 @@ import {
   exportAllAsZip,
   exportAllAsSingleSTL,
 } from '@/engine/export/stlExporter'
+import { exportObjectAs3MF, exportAllAs3MF } from '@/engine/export/threeMfExporter'
 import type { CurveQuality } from '@/types/gridfinity'
 
 export function PrintSettingsPanel() {
@@ -79,6 +86,22 @@ export function PrintSettingsPanel() {
     const rotation = getPrintRotation(obj)
     const oriented = applyPrintOrientation(merged, rotation)
     exportObjectAsSTL(oriented, obj.name, exportScale)
+    merged.dispose()
+    oriented.dispose()
+  }
+
+  const handleExportAll3MF = () => {
+    if (layoutItems.length === 0) return
+    void exportAllAs3MF(layoutItems, exportScale)
+  }
+
+  const handleExportOne3MF = (objectId: string) => {
+    const obj = objects.find((o) => o.id === objectId)
+    if (!obj) return
+    const merged = mergeObjectWithModifiers(obj, modifiers, activeProfile)
+    const rotation = getPrintRotation(obj)
+    const oriented = applyPrintOrientation(merged, rotation)
+    void exportObjectAs3MF(oriented, obj.name, exportScale)
     merged.dispose()
     oriented.dispose()
   }
@@ -196,17 +219,34 @@ export function PrintSettingsPanel() {
                         {item.boundingBox.height.toFixed(1)} mm
                       </div>
                     </div>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-8 w-8 shrink-0 md:h-6 md:w-6"
-                      onClick={() => {
-                        handleExportOne(item.object.id)
-                      }}
-                      aria-label={`Export ${item.object.name}`}
-                    >
-                      <Download className="h-4 w-4 md:h-3 md:w-3" />
-                    </Button>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-8 w-8 shrink-0 md:h-6 md:w-6"
+                          aria-label={`Export ${item.object.name}`}
+                        >
+                          <Download className="h-4 w-4 md:h-3 md:w-3" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem
+                          onClick={() => {
+                            handleExportOne(item.object.id)
+                          }}
+                        >
+                          Export as STL
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onClick={() => {
+                            handleExportOne3MF(item.object.id)
+                          }}
+                        >
+                          Export as 3MF
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
                   </div>
                 ))}
               </div>
@@ -241,6 +281,16 @@ export function PrintSettingsPanel() {
             >
               <Download className="h-4 w-4" />
               Export Plate (Single STL)
+            </Button>
+            <Button
+              className="w-full gap-2"
+              variant="outline"
+              size="sm"
+              onClick={handleExportAll3MF}
+              disabled={layoutItems.length === 0}
+            >
+              <Download className="h-4 w-4" />
+              Export All (3MF)
             </Button>
           </div>
         </div>

--- a/src/components/toolbar/Toolbar.tsx
+++ b/src/components/toolbar/Toolbar.tsx
@@ -40,6 +40,7 @@ import { cn } from '@/lib/utils'
 import { mergeObjectWithModifiers } from '@/engine/export/mergeObjectGeometry'
 import { getPrintRotation, applyPrintOrientation } from '@/engine/export/printOrientation'
 import { exportObjectAsSTL } from '@/engine/export/stlExporter'
+import { exportObjectAs3MF } from '@/engine/export/threeMfExporter'
 import type { ViewportBackground, LightingPreset, CameraPreset } from '@/types/gridfinity'
 
 export function Toolbar() {
@@ -93,6 +94,19 @@ export function Toolbar() {
     const rotation = getPrintRotation(obj)
     const oriented = applyPrintOrientation(merged, rotation)
     exportObjectAsSTL(oriented, obj.name, exportScale)
+    merged.dispose()
+    oriented.dispose()
+  }
+
+  const handleExportSelected3MF = () => {
+    if (!selectedObjectId) return
+    const obj = objects.find((o) => o.id === selectedObjectId)
+    if (!obj) return
+
+    const merged = mergeObjectWithModifiers(obj, modifiers, activeProfile)
+    const rotation = getPrintRotation(obj)
+    const oriented = applyPrintOrientation(merged, rotation)
+    void exportObjectAs3MF(oriented, obj.name, exportScale)
     merged.dispose()
     oriented.dispose()
   }
@@ -307,6 +321,12 @@ export function Toolbar() {
               disabled={!selectedObjectId || !isEditView}
             >
               Export Selected (STL)
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={handleExportSelected3MF}
+              disabled={!selectedObjectId || !isEditView}
+            >
+              Export Selected (3MF)
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem

--- a/src/engine/export/__tests__/threeMfExporter.test.ts
+++ b/src/engine/export/__tests__/threeMfExporter.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import * as THREE from 'three'
+import JSZip from 'jszip'
+import { exportObjectAs3MF, exportAllAs3MF } from '../threeMfExporter'
+import { generateBaseplate } from '../../geometry/baseplate'
+import { PROFILE_OFFICIAL } from '../../constants'
+import type { PrintLayoutItem } from '../printLayout'
+import type { BaseplateObject } from '@/types/gridfinity'
+
+let downloadState: { triggered: boolean; filename: string }
+let capturedBlob: Blob | null
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  downloadState = { triggered: false, filename: '' }
+  capturedBlob = null
+
+  vi.stubGlobal('URL', {
+    ...globalThis.URL,
+    createObjectURL: vi.fn((blob: Blob) => {
+      capturedBlob = blob
+      return 'blob:mock-url'
+    }),
+    revokeObjectURL: vi.fn(),
+  })
+
+  const mockLink = {
+    href: '',
+    download: '',
+    click: () => {
+      downloadState.triggered = true
+      downloadState.filename = mockLink.download
+    },
+  }
+  vi.spyOn(document, 'createElement').mockReturnValue(mockLink as unknown as HTMLElement)
+  vi.spyOn(document.body, 'appendChild').mockImplementation(() => mockLink as unknown as Node)
+  vi.spyOn(document.body, 'removeChild').mockImplementation(() => mockLink as unknown as Node)
+})
+
+function makeTestGeometry(): THREE.BufferGeometry {
+  const geometry = new THREE.BufferGeometry()
+  const vertices = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0])
+  const normals = new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1])
+  geometry.setAttribute('position', new THREE.BufferAttribute(vertices, 3))
+  geometry.setAttribute('normal', new THREE.BufferAttribute(normals, 3))
+  geometry.setIndex([0, 1, 2])
+  return geometry
+}
+
+async function readModelXml(): Promise<string> {
+  if (capturedBlob === null) {
+    throw new Error('Expected capturedBlob to be set')
+  }
+  const zip = await JSZip.loadAsync(capturedBlob)
+  const modelFile = zip.file('3D/3dmodel.model')
+  if (modelFile === null) {
+    throw new Error('Expected 3D/3dmodel.model in ZIP')
+  }
+  return modelFile.async('string')
+}
+
+describe('exportObjectAs3MF', () => {
+  it('triggers a download with .3mf extension', async () => {
+    const geo = makeTestGeometry()
+    await exportObjectAs3MF(geo, 'test-object')
+
+    expect(downloadState.triggered).toBe(true)
+    expect(downloadState.filename).toBe('test-object.3mf')
+
+    geo.dispose()
+  })
+
+  it('sanitizes filenames with special characters', async () => {
+    const geo = makeTestGeometry()
+    await exportObjectAs3MF(geo, 'my/object<name>')
+
+    expect(downloadState.filename).toBe('my_object_name_.3mf')
+
+    geo.dispose()
+  })
+
+  it('produces a valid ZIP with required 3MF entries', async () => {
+    const geo = makeTestGeometry()
+    await exportObjectAs3MF(geo, 'test')
+
+    if (capturedBlob === null) {
+      throw new Error('Expected capturedBlob to be set')
+    }
+    const zip = await JSZip.loadAsync(capturedBlob)
+    expect(zip.file('[Content_Types].xml')).not.toBeNull()
+    expect(zip.file('_rels/.rels')).not.toBeNull()
+    expect(zip.file('3D/3dmodel.model')).not.toBeNull()
+
+    geo.dispose()
+  })
+
+  it('generates correct vertex and triangle counts in model XML', async () => {
+    const geo = makeTestGeometry()
+    await exportObjectAs3MF(geo, 'test')
+
+    const modelXml = await readModelXml()
+
+    expect((modelXml.match(/<vertex /g) ?? []).length).toBe(3)
+    expect((modelXml.match(/<triangle /g) ?? []).length).toBe(1)
+
+    geo.dispose()
+  })
+
+  it('declares millimeter units in model XML', async () => {
+    const geo = makeTestGeometry()
+    await exportObjectAs3MF(geo, 'test')
+
+    const modelXml = await readModelXml()
+    expect(modelXml).toContain('unit="millimeter"')
+
+    geo.dispose()
+  })
+
+  it('escapes XML special characters in object names', async () => {
+    const geo = makeTestGeometry()
+    await exportObjectAs3MF(geo, 'Bin <1> & "2"')
+
+    const modelXml = await readModelXml()
+    expect(modelXml).toContain('Bin &lt;1&gt; &amp; &quot;2&quot;')
+
+    geo.dispose()
+  })
+
+  it('handles real baseplate geometry', async () => {
+    const params = { gridWidth: 1, gridDepth: 1, magnetHoles: false, screwHoles: false }
+    const geo = generateBaseplate(params, PROFILE_OFFICIAL)
+
+    await expect(exportObjectAs3MF(geo, 'Baseplate')).resolves.not.toThrow()
+
+    geo.dispose()
+  })
+
+  it('applies scale factor when not equal to 1', async () => {
+    const geo = makeTestGeometry()
+    await exportObjectAs3MF(geo, 'scaled', 2)
+
+    const modelXml = await readModelXml()
+    // Original vertex at (1,0,0) should become (2,0,0) with scale=2
+    expect(modelXml).toContain('x="2.000000"')
+
+    geo.dispose()
+  })
+})
+
+describe('exportAllAs3MF', () => {
+  it('does nothing with empty items', async () => {
+    await exportAllAs3MF([])
+    expect(downloadState.triggered).toBe(false)
+  })
+
+  it('exports multiple objects in a single 3MF', async () => {
+    const bp: BaseplateObject = {
+      id: 'bp-1',
+      name: 'Baseplate 1',
+      kind: 'baseplate',
+      position: [0, 0, 0],
+      params: { gridWidth: 1, gridDepth: 1, magnetHoles: false, screwHoles: false },
+    }
+
+    const items: PrintLayoutItem[] = [
+      {
+        object: bp,
+        geometry: makeTestGeometry(),
+        position: [0, 0, 0],
+        boundingBox: { width: 42, depth: 42, height: 7 },
+        fitsOnBed: true,
+      },
+      {
+        object: { ...bp, id: 'bp-2', name: 'Baseplate 2' },
+        geometry: makeTestGeometry(),
+        position: [52, 0, 0],
+        boundingBox: { width: 42, depth: 42, height: 7 },
+        fitsOnBed: true,
+      },
+    ]
+
+    await exportAllAs3MF(items)
+
+    expect(downloadState.triggered).toBe(true)
+    expect(downloadState.filename).toBe('react-finity-plate.3mf')
+
+    const modelXml = await readModelXml()
+
+    expect((modelXml.match(/<object /g) ?? []).length).toBe(2)
+    expect((modelXml.match(/<item /g) ?? []).length).toBe(2)
+
+    for (const item of items) {
+      item.geometry.dispose()
+    }
+  })
+})

--- a/src/engine/export/threeMfExporter.ts
+++ b/src/engine/export/threeMfExporter.ts
@@ -1,0 +1,176 @@
+import type * as THREE from 'three'
+import JSZip from 'jszip'
+import type { PrintLayoutItem } from './printLayout'
+
+function sanitizeFilename(name: string): string {
+  return name.replace(/[^a-zA-Z0-9_\-. ]/g, '_').trim() || 'object'
+}
+
+function triggerDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = filename
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(url)
+}
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}
+
+function geometryToMeshXml(geometry: THREE.BufferGeometry, scale: number): string {
+  const positions = geometry.attributes.position
+  const parts: string[] = []
+
+  parts.push('        <vertices>\n')
+  for (let i = 0; i < positions.count; i++) {
+    const x = positions.getX(i) * scale
+    const y = positions.getY(i) * scale
+    const z = positions.getZ(i) * scale
+    parts.push(`          <vertex x="${x.toFixed(6)}" y="${y.toFixed(6)}" z="${z.toFixed(6)}" />\n`)
+  }
+  parts.push('        </vertices>\n')
+
+  parts.push('        <triangles>\n')
+  const index = geometry.index
+  if (index) {
+    for (let i = 0; i < index.count; i += 3) {
+      parts.push(
+        `          <triangle v1="${index.getX(i)}" v2="${index.getX(i + 1)}" v3="${index.getX(i + 2)}" />\n`,
+      )
+    }
+  } else {
+    for (let i = 0; i < positions.count; i += 3) {
+      parts.push(`          <triangle v1="${i}" v2="${i + 1}" v3="${i + 2}" />\n`)
+    }
+  }
+  parts.push('        </triangles>\n')
+
+  return parts.join('')
+}
+
+interface ModelObject {
+  id: number
+  name: string
+  meshXml: string
+}
+
+interface BuildItem {
+  objectId: number
+}
+
+function buildModelXml(objects: ModelObject[], buildItems: BuildItem[]): string {
+  const parts: string[] = []
+  parts.push('<?xml version="1.0" encoding="UTF-8"?>\n')
+  parts.push('<model unit="millimeter" xml:lang="en-US"\n')
+  parts.push('  xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02">\n')
+
+  parts.push('  <resources>\n')
+  for (const obj of objects) {
+    parts.push(`    <object id="${obj.id}" type="model" name="${escapeXml(obj.name)}">\n`)
+    parts.push('      <mesh>\n')
+    parts.push(obj.meshXml)
+    parts.push('      </mesh>\n')
+    parts.push('    </object>\n')
+  }
+  parts.push('  </resources>\n')
+
+  parts.push('  <build>\n')
+  for (const item of buildItems) {
+    parts.push(`    <item objectid="${item.objectId}" />\n`)
+  }
+  parts.push('  </build>\n')
+
+  parts.push('</model>\n')
+  return parts.join('')
+}
+
+function buildContentTypesXml(): string {
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">',
+    '  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml" />',
+    '  <Default Extension="model" ContentType="application/vnd.ms-package.3dmanufacturing-3dmodel+xml" />',
+    '</Types>',
+    '',
+  ].join('\n')
+}
+
+function buildRelsXml(): string {
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">',
+    '  <Relationship Target="/3D/3dmodel.model" Id="rel0"',
+    '    Type="http://schemas.microsoft.com/3dmanufacturing/2013/01/3dmodel" />',
+    '</Relationships>',
+    '',
+  ].join('\n')
+}
+
+async function build3MFBlob(modelXml: string): Promise<Blob> {
+  const zip = new JSZip()
+  zip.file('[Content_Types].xml', buildContentTypesXml())
+  zip.file('_rels/.rels', buildRelsXml())
+  zip.file('3D/3dmodel.model', modelXml)
+  return zip.generateAsync({
+    type: 'blob',
+    mimeType: 'application/vnd.ms-package.3dmanufacturing-3dmodel+xml',
+  })
+}
+
+/**
+ * Export a single geometry as a 3MF file download.
+ * Scale defaults to 1 since 3MF declares unit="millimeter" explicitly.
+ */
+export async function exportObjectAs3MF(
+  geometry: THREE.BufferGeometry,
+  name: string,
+  scale = 1,
+): Promise<void> {
+  const meshXml = geometryToMeshXml(geometry, scale)
+  const modelXml = buildModelXml([{ id: 1, name, meshXml }], [{ objectId: 1 }])
+  const blob = await build3MFBlob(modelXml)
+  triggerDownload(blob, `${sanitizeFilename(name)}.3mf`)
+}
+
+/**
+ * Export all print layout items as separate objects in a single 3MF file.
+ * Each item becomes a separate <object> element with position pre-translated
+ * into the geometry (consistent with exportAllAsSingleSTL approach).
+ */
+export async function exportAllAs3MF(items: PrintLayoutItem[], scale = 1): Promise<void> {
+  if (items.length === 0) return
+
+  const objects: ModelObject[] = []
+  const buildItems: BuildItem[] = []
+  const clones: THREE.BufferGeometry[] = []
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i]
+    const clone = item.geometry.clone()
+    const [x, y, z] = item.position
+    clone.translate(x, y, z)
+    clones.push(clone)
+
+    const id = i + 1
+    const meshXml = geometryToMeshXml(clone, scale)
+    objects.push({ id, name: item.object.name, meshXml })
+    buildItems.push({ objectId: id })
+  }
+
+  const modelXml = buildModelXml(objects, buildItems)
+  const blob = await build3MFBlob(modelXml)
+  triggerDownload(blob, 'react-finity-plate.3mf')
+
+  for (const clone of clones) {
+    clone.dispose()
+  }
+}


### PR DESCRIPTION
## Summary
Implements 3MF (3D Manufacturing Format) export functionality alongside existing STL export, allowing users to export individual objects or entire print plates as OPC-compliant 3MF archives.

## Key Changes

- **New 3MF exporter module** (`src/engine/export/threeMfExporter.ts`):
  - `exportObjectAs3MF()` — exports a single geometry with optional scale factor
  - `exportAllAs3MF()` — exports multiple print layout items as separate objects in one 3MF file
  - Proper XML generation with vertex/triangle data and millimeter unit declaration
  - JSZip-based OPC archive creation with required `[Content_Types].xml`, `_rels/.rels`, and `3D/3dmodel.model` entries
  - Filename sanitization and XML entity escaping

- **UI integration** in Print Settings Panel:
  - Added "Export All (3MF)" button for batch export
  - Per-object export dropdown menu with STL and 3MF format options
  - Consistent with existing STL export patterns

- **Toolbar export menu**:
  - Added "Export Selected (3MF)" option alongside STL export
  - Proper enable/disable state management

- **Comprehensive test coverage** (`src/engine/export/__tests__/threeMfExporter.test.ts`):
  - 196 lines of unit tests covering single and batch exports
  - Validates ZIP structure, XML format, vertex/triangle counts, unit declarations
  - Tests filename sanitization, XML escaping, and scale factor application
  - Includes real baseplate geometry validation

- **E2E test updates**:
  - Updated export menu tests to distinguish between STL and 3MF options
  - Added tests for 3MF export triggers and button states
  - Print layout view tests for per-object and batch 3MF export

## Implementation Details

- 3MF files use millimeter units explicitly (`unit="millimeter"`)
- Geometries are cloned and translated to their print positions before export (consistent with STL approach)
- Each object in a batch export becomes a separate `<object>` element with its own mesh
- Scale factor defaults to 1 but can be customized (0.1x–10x range)
- Downloads use standard browser blob/link pattern with proper cleanup

https://claude.ai/code/session_018K7aC4zq51ToNNWDWme3vA