### PR TITLE
Improve e2e test speed with sharding, parallel workers, and test consolidation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -255,7 +255,7 @@ jobs:
         run: exit 1
 
   e2e-tests:
-    name: E2E Tests
+    name: E2E Tests (shard ${{ matrix.shardIndex }}/${{ strategy.job-total }})
     runs-on: ubuntu-latest
     needs: [changes]
     if: >-
@@ -263,6 +263,11 @@ jobs:
       needs.changes.outputs.e2e == 'true' ||
       needs.changes.outputs.config == 'true' ||
       needs.changes.outputs.ci == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2, 3]
+        shardTotal: [3]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -280,13 +285,49 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Run E2E tests
-        id: tests
-        continue-on-error: true
-        run: npx playwright test
+        run: npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+
+      - name: Upload blob report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: blob-report-${{ matrix.shardIndex }}
+          path: blob-report
+          retention-days: 1
+
+  e2e-report:
+    name: E2E Test Report
+    runs-on: ubuntu-latest
+    needs: [e2e-tests]
+    if: always() && needs.e2e-tests.result != 'skipped'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download blob reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: blob-report-*
+          merge-multiple: true
+          path: all-blob-reports
+
+      - name: Merge reports
+        run: npx playwright merge-reports --reporter=html,junit ./all-blob-reports
+        env:
+          PLAYWRIGHT_JUNIT_OUTPUT_NAME: test-results/playwright-junit.xml
 
       - name: Test report
         uses: dorny/test-reporter@v1
-        if: success() || failure()
+        if: always()
         with:
           name: Playwright Results
           path: test-results/playwright-junit.xml
@@ -298,7 +339,7 @@ jobs:
           echo "## E2E Test Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          if [ "${{ steps.tests.outcome }}" = "success" ]; then
+          if [ "${{ needs.e2e-tests.result }}" = "success" ]; then
             echo ":white_check_mark: **All E2E tests passed**" >> $GITHUB_STEP_SUMMARY
           else
             echo ":x: **E2E test failures detected**" >> $GITHUB_STEP_SUMMARY
@@ -308,23 +349,11 @@ jobs:
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4
-        if: success() || failure()
+        if: always()
         with:
           name: playwright-report
           path: playwright-report/
           retention-days: 14
-
-      - name: Upload trace results
-        uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: playwright-traces
-          path: test-results/
-          retention-days: 14
-
-      - name: Fail on test failures
-        if: steps.tests.outcome == 'failure'
-        run: exit 1
 
   build:
     name: Build
@@ -383,7 +412,7 @@ jobs:
   validation-complete:
     name: Validation Complete
     if: always()
-    needs: [lint, typecheck, unit-tests, e2e-tests, build]
+    needs: [lint, typecheck, unit-tests, e2e-tests, e2e-report, build]
     runs-on: ubuntu-latest
     steps:
       - name: Check job results

--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -1,35 +1,22 @@
 import { test, expect } from '@playwright/test'
 
 test.describe('App Loading & Initial State', () => {
-  test.beforeEach(async ({ page }) => {
+  test('renders toolbar, panels, and viewport on load', async ({ page }) => {
     await page.goto('/')
-  })
 
-  test('renders the project name in the toolbar', async ({ page }) => {
+    // Toolbar
     await expect(page.getByTestId('project-name')).toBeVisible()
-  })
+    await expect(page.getByRole('button', { name: /Add Object/i })).toBeVisible()
 
-  test('shows the Add Object button', async ({ page }) => {
-    await expect(
-      page.getByRole('button', { name: /Add Object/i }),
-    ).toBeVisible()
-  })
-
-  test('shows the Objects panel with empty state', async ({ page }) => {
+    // Left panel - Objects
     await expect(page.getByText('Objects', { exact: true })).toBeVisible()
-    await expect(
-      page.getByText('No objects yet. Use "Add Object" to get started.'),
-    ).toBeVisible()
-  })
+    await expect(page.getByText('No objects yet. Use "Add Object" to get started.')).toBeVisible()
 
-  test('shows the Properties panel with empty state', async ({ page }) => {
+    // Right panel - Properties
     await expect(page.getByText('Properties', { exact: true })).toBeVisible()
-    await expect(
-      page.getByText('Select an object to view its properties.'),
-    ).toBeVisible()
-  })
+    await expect(page.getByText('Select an object to view its properties.')).toBeVisible()
 
-  test('renders the 3D viewport canvas', async ({ page }) => {
+    // 3D Viewport
     await expect(page.locator('canvas')).toBeVisible()
   })
 })

--- a/e2e/bin-properties.spec.ts
+++ b/e2e/bin-properties.spec.ts
@@ -1,10 +1,5 @@
 import { test, expect } from '@playwright/test'
-import type { Page } from '@playwright/test'
-
-async function addBin(page: Page) {
-  await page.getByRole('button', { name: /Add Object/i }).click()
-  await page.getByRole('menuitem', { name: 'Bin' }).click()
-}
+import { addBin } from './fixtures'
 
 test.describe('Bin Properties Panel', () => {
   test.beforeEach(async ({ page }) => {

--- a/e2e/camera-presets.spec.ts
+++ b/e2e/camera-presets.spec.ts
@@ -12,33 +12,11 @@ test.describe('Camera Presets', () => {
     await expect(page.getByRole('button', { name: 'Isometric View' })).toBeVisible()
   })
 
-  test('clicking top view does not crash', async ({ page }) => {
-    await page.getByRole('button', { name: 'Top View' }).click()
-    // Canvas should still be rendered
-    await expect(page.locator('canvas')).toBeVisible()
-  })
-
-  test('clicking front view does not crash', async ({ page }) => {
-    await page.getByRole('button', { name: 'Front View' }).click()
-    await expect(page.locator('canvas')).toBeVisible()
-  })
-
-  test('clicking side view does not crash', async ({ page }) => {
-    await page.getByRole('button', { name: 'Side View' }).click()
-    await expect(page.locator('canvas')).toBeVisible()
-  })
-
-  test('clicking isometric view does not crash', async ({ page }) => {
-    await page.getByRole('button', { name: 'Isometric View' }).click()
-    await expect(page.locator('canvas')).toBeVisible()
-  })
-
-  test('clicking all presets in sequence does not cause errors', async ({ page }) => {
-    await page.getByRole('button', { name: 'Top View' }).click()
-    await page.getByRole('button', { name: 'Front View' }).click()
-    await page.getByRole('button', { name: 'Side View' }).click()
-    await page.getByRole('button', { name: 'Isometric View' }).click()
-    await expect(page.locator('canvas')).toBeVisible()
+  test('clicking each preset in sequence does not crash', async ({ page }) => {
+    for (const preset of ['Top View', 'Front View', 'Side View', 'Isometric View']) {
+      await page.getByRole('button', { name: preset }).click()
+      await expect(page.locator('canvas')).toBeVisible()
+    }
   })
 
   test('camera presets work with objects in the scene', async ({ page }) => {

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,11 @@
+import type { Page } from '@playwright/test'
+
+export async function addBaseplate(page: Page) {
+  await page.getByRole('button', { name: /Add Object/i }).click()
+  await page.getByRole('menuitem', { name: 'Baseplate' }).click()
+}
+
+export async function addBin(page: Page) {
+  await page.getByRole('button', { name: /Add Object/i }).click()
+  await page.getByRole('menuitem', { name: 'Bin' }).click()
+}

--- a/e2e/keyboard-shortcuts.spec.ts
+++ b/e2e/keyboard-shortcuts.spec.ts
@@ -1,15 +1,5 @@
 import { test, expect } from '@playwright/test'
-import type { Page } from '@playwright/test'
-
-async function addBaseplate(page: Page) {
-  await page.getByRole('button', { name: /Add Object/i }).click()
-  await page.getByRole('menuitem', { name: 'Baseplate' }).click()
-}
-
-async function addBin(page: Page) {
-  await page.getByRole('button', { name: /Add Object/i }).click()
-  await page.getByRole('menuitem', { name: 'Bin' }).click()
-}
+import { addBaseplate, addBin } from './fixtures'
 
 test.describe('Keyboard Shortcuts', () => {
   test.beforeEach(async ({ page }) => {

--- a/e2e/measurement-overlay.spec.ts
+++ b/e2e/measurement-overlay.spec.ts
@@ -1,15 +1,5 @@
 import { test, expect } from '@playwright/test'
-import type { Page } from '@playwright/test'
-
-async function addBaseplate(page: Page) {
-  await page.getByRole('button', { name: /Add Object/i }).click()
-  await page.getByRole('menuitem', { name: 'Baseplate' }).click()
-}
-
-async function addBin(page: Page) {
-  await page.getByRole('button', { name: /Add Object/i }).click()
-  await page.getByRole('menuitem', { name: 'Bin' }).click()
-}
+import { addBaseplate, addBin } from './fixtures'
 
 test.describe('Measurement Overlay', () => {
   test.beforeEach(async ({ page }) => {

--- a/e2e/object-list.spec.ts
+++ b/e2e/object-list.spec.ts
@@ -1,15 +1,5 @@
 import { test, expect } from '@playwright/test'
-import type { Page } from '@playwright/test'
-
-async function addBaseplate(page: Page) {
-  await page.getByRole('button', { name: /Add Object/i }).click()
-  await page.getByRole('menuitem', { name: 'Baseplate' }).click()
-}
-
-async function addBin(page: Page) {
-  await page.getByRole('button', { name: /Add Object/i }).click()
-  await page.getByRole('menuitem', { name: 'Bin' }).click()
-}
+import { addBaseplate, addBin } from './fixtures'
 
 test.describe('Object List', () => {
   test.beforeEach(async ({ page }) => {

--- a/e2e/project-management.spec.ts
+++ b/e2e/project-management.spec.ts
@@ -2,12 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test.describe('Project Management', () => {
   test.beforeEach(async ({ page }) => {
-    // Clear localStorage before each test
     await page.goto('/')
-    await page.evaluate(() => {
-      localStorage.clear()
-    })
-    await page.reload()
   })
 
   test('shows Project dropdown in toolbar', async ({ page }) => {
@@ -71,9 +66,8 @@ test.describe('Project Management', () => {
     // Wait for the object to appear in the object list
     await expect(page.getByText(/Bin \d+/).first()).toBeVisible()
 
-    // Click somewhere to ensure no dropdown is open
-    await page.mouse.click(400, 300)
-    await page.waitForTimeout(200)
+    // Ensure no dropdown is open before opening the Project menu
+    await page.keyboard.press('Escape')
 
     // New Project
     await page.getByRole('button', { name: /Project/ }).click()
@@ -137,17 +131,17 @@ test.describe('Project Management', () => {
     await page.getByLabel('Project name').fill('Persist Test')
     await page.getByRole('button', { name: /^Save$/ }).click()
 
-    // Wait for save to complete
-    await page.waitForTimeout(500)
+    // Wait for project name to confirm save completed
+    await expect(page.getByTestId('project-name')).toHaveText('Persist Test')
 
     // Reload the page
     await page.reload()
 
-    // Project name should be restored
+    // Project name should be restored (extra timeout for hydration)
     const projectName = page.getByTestId('project-name')
-    await expect(projectName).toHaveText('Persist Test', { timeout: 10000 })
+    await expect(projectName).toHaveText('Persist Test', { timeout: 7000 })
 
-    // Objects should be restored in the object list (with extra timeout for hydration)
-    await expect(page.getByText(/Bin \d+/).first()).toBeVisible({ timeout: 10000 })
+    // Objects should be restored in the object list
+    await expect(page.getByText(/Bin \d+/).first()).toBeVisible({ timeout: 7000 })
   })
 })

--- a/e2e/properties-panel.spec.ts
+++ b/e2e/properties-panel.spec.ts
@@ -1,10 +1,5 @@
 import { test, expect } from '@playwright/test'
-import type { Page } from '@playwright/test'
-
-async function addBaseplate(page: Page) {
-  await page.getByRole('button', { name: /Add Object/i }).click()
-  await page.getByRole('menuitem', { name: 'Baseplate' }).click()
-}
+import { addBaseplate } from './fixtures'
 
 test.describe('Properties Panel', () => {
   test.beforeEach(async ({ page }) => {

--- a/e2e/transform-gizmo.spec.ts
+++ b/e2e/transform-gizmo.spec.ts
@@ -1,15 +1,5 @@
 import { test, expect } from '@playwright/test'
-import type { Page } from '@playwright/test'
-
-async function addBaseplate(page: Page) {
-  await page.getByRole('button', { name: /Add Object/i }).click()
-  await page.getByRole('menuitem', { name: 'Baseplate' }).click()
-}
-
-async function addBin(page: Page) {
-  await page.getByRole('button', { name: /Add Object/i }).click()
-  await page.getByRole('menuitem', { name: 'Bin' }).click()
-}
+import { addBaseplate, addBin } from './fixtures'
 
 test.describe('Transform Gizmo', () => {
   test.beforeEach(async ({ page }) => {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,14 +7,11 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: isCI,
   retries: isCI ? 2 : 0,
-  workers: isCI ? 1 : undefined,
-  reporter: isCI
-    ? [
-        ['list'],
-        ['junit', { outputFile: 'test-results/playwright-junit.xml' }],
-        ['html', { open: 'never' }],
-      ]
-    : 'html',
+  timeout: 20_000,
+  expect: {
+    timeout: 3_000,
+  },
+  reporter: isCI ? [['blob'], ['list']] : 'html',
   use: {
     baseURL: 'http://localhost:5173',
     trace: 'on-first-retry',


### PR DESCRIPTION
- Remove CI worker restriction (was forced to 1), allowing parallel execution
- Add 3-way test sharding in CI with blob report merging for parallel jobs
- Add explicit test timeout (20s) and expect timeout (3s) for faster failures
- Remove hardcoded waitForTimeout() calls in project-management tests
- Remove unnecessary localStorage clear + reload in project-management beforeEach
- Consolidate trivial tests (app initial state: 5->1, camera presets: 5->1)
- Extract shared addBaseplate/addBin helpers into e2e/fixtures.ts

https://claude.ai/code/session_01H8nACATjfaArmnbqXGZpjQ