### PR TITLE
Fix code analysis round 12: 3MF position guard, CSG double-dispose

### DIFF
--- a/src/engine/export/__tests__/threeMfExporter.test.ts
+++ b/src/engine/export/__tests__/threeMfExporter.test.ts
@@ -126,6 +126,21 @@ describe('exportObjectAs3MF', () => {
     geo.dispose()
   })
 
+  it('handles geometry without position attribute', async () => {
+    const geo = new BufferGeometry()
+    exportObjectAs3MF(geo, 'empty')
+
+    const modelXml = await readModelXml()
+    expect(modelXml).toContain('<vertices>')
+    expect(modelXml).toContain('</vertices>')
+    expect(modelXml).toContain('<triangles>')
+    expect(modelXml).toContain('</triangles>')
+    expect((modelXml.match(/<vertex /g) ?? []).length).toBe(0)
+    expect((modelXml.match(/<triangle /g) ?? []).length).toBe(0)
+
+    geo.dispose()
+  })
+
   it('handles real baseplate geometry', () => {
     const params = {
       gridWidth: 1,

--- a/src/engine/export/mergeObjectGeometry.ts
+++ b/src/engine/export/mergeObjectGeometry.ts
@@ -159,10 +159,13 @@ export function mergeObjectWithModifiers(
 
       try {
         const csgResult = evaluator.evaluate(baseBrush, subtractBrush, SUBTRACTION)
-        const finalGeometry = csgResult.geometry
-        result.dispose()
-        result = finalGeometry
+        result = csgResult.geometry
       } finally {
+        // Brush holds a reference to the geometry passed to its constructor,
+        // so baseBrush.geometry === (old) result. Disposing here covers both
+        // the success path (old result replaced) and error path (old result
+        // still assigned but unusable). Avoid disposing result directly above
+        // to prevent double-dispose.
         baseBrush.geometry.dispose()
         subtractBrush.geometry.dispose()
       }

--- a/src/engine/export/threeMfExporter.ts
+++ b/src/engine/export/threeMfExporter.ts
@@ -12,6 +12,9 @@ function escapeXml(str: string): string {
 }
 
 function geometryToMeshXml(geometry: BufferGeometry, scale: number): string {
+  if (!('position' in geometry.attributes)) {
+    return '        <vertices>\n        </vertices>\n        <triangles>\n        </triangles>\n'
+  }
   const positions = geometry.attributes.position
   const parts: string[] = []
 


### PR DESCRIPTION
## Summary
- Guard `geometryToMeshXml` in 3MF exporter against geometry without a position attribute, consistent with `mergeGeometries` and `exportAllAsSingleSTL`
- Remove redundant `result.dispose()` in CSG subtraction path — `baseBrush.geometry.dispose()` in the finally block already handles the same object, preventing double-disposal

## Test plan
- [x] `npm run test` — 535 unit tests pass (1 new test for empty geometry 3MF export)
- [x] `npm run build` — TypeScript compiles and production build succeeds
- [x] All existing export and merge tests continue to pass

Generated with [Claude Code](https://claude.com/claude-code)